### PR TITLE
Add developer section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,34 @@ The grid starts at 10×10. Add rows and columns as needed to fit longer words or
 ## Installation
 
 Words works in any modern browser and can be installed as an app. Look for the install prompt in your browser's address bar or menu to add it to your home screen or desktop for offline use.
+
+## Development
+
+**Stack:** Vanilla JS · Vite 8 · Sass · Vitest · ESLint · Yarn 4 · Node 24
+
+```bash
+yarn dev        # Dev server at localhost:3080 (HMR)
+yarn build      # Production build → dist/
+yarn preview    # Preview production build at localhost:3080
+yarn lint       # Lint src and test files
+yarn lint:fix   # Lint and auto-fix
+yarn test       # Run test suite (single run)
+yarn test:watch # Run tests in watch mode
+yarn coverage   # Run tests with coverage report
+```
+
+## Testing
+
+51 tests across 5 files using Vitest + jsdom. Tests live in `test/` and cover game state, grid mutations, toggle persistence, keyboard shortcuts, and localStorage cleanup.
+
+```bash
+yarn test
+```
+
+## Deployment
+
+Deployed to [craigmcn.com/words](https://www.craigmcn.com/words/) via Netlify. The production build outputs to `netlify/` and is also copied to `netlify/words/` for Netlify routing under the `/words/` sub-path.
+
+```bash
+yarn build:netlify
+```


### PR DESCRIPTION
## Summary
- Adds **Development**, **Testing**, and **Deployment** sections to the README, matching the pattern used by other modernized repos in the suite (currency, markdown, math-tiles, etc.)
- Covers stack, all yarn commands, test summary (51 tests / 5 files), and Netlify deployment

## Test plan
- [ ] Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)