### PR TITLE
Add husky pre-commit hook (lint + test)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn lint && yarn test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 - **Vitest 4** — replaced Jest + jest-environment-jsdom; config inline in `vite.config.js` (`globals: true`, `environment: jsdom`)
 - **CI** — `test.yml` updated: `corepack enable` → `setup-node` with `cache: yarn` → `yarn install --immutable` → lint → build → `yarn coverage`
 - **Branch protection** — require PR, 1 approval, `enforce_admins: false` (owner bypass), require `test` status check, dismiss stale reviews, block force push + deletion
+- **Husky** — pre-commit hook runs `yarn lint && yarn test` (PR #57)
 
 ### Key decisions
 - **TypeScript: N/A** — intentionally vanilla JS PWA (same as `cryptogram`); not worth the migration cost for a game with no shared types
@@ -87,8 +88,10 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 - **CSS output** — Vite merges all CSS (albert.min.css + styles.scss + tippy.css) into a single `css/index.css`; sw.js updated accordingly
 - **Netlify copy** — `scripts/copy-netlify.mjs` copies individual entries from `netlify/` → `netlify/words/` (not the directory itself, to avoid self-copy error)
 
-### Nothing outstanding
-Modernization is complete. No open TODOs or blockers.
+### In progress
+- **ESLint indent** — switching 4-space → 2-space (PR #56)
+- **Husky** — pre-commit hooks (PR #57)
+- **vite.config.ts** — rename vite.config.js → vite.config.ts (planned)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Words works in any modern browser and can be installed as an app. Look for the i
 
 ## Development
 
-**Stack:** Vanilla JS · Vite 8 · Sass · Vitest · ESLint · Yarn 4 · Node 24
+**Stack:** Vanilla JS · Vite 8 · Sass · Vitest · ESLint · Husky · Yarn 4 · Node 24
 
 ```bash
 yarn dev        # Dev server at localhost:3080 (HMR)
@@ -48,6 +48,8 @@ yarn test       # Run test suite (single run)
 yarn test:watch # Run tests in watch mode
 yarn coverage   # Run tests with coverage report
 ```
+
+A pre-commit hook (husky) runs `yarn lint && yarn test` automatically before each commit.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,52 +1,54 @@
 {
-    "name": "words",
-    "version": "1.4.0",
-    "description": "A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/).",
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "build:netlify": "vite build --mode netlify && node scripts/copy-netlify.mjs",
-        "preview": "vite preview --port 3080",
-        "lint": "eslint src test",
-        "lint:fix": "eslint src test --fix",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "coverage": "vitest run --coverage"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/craigmcn/words.git"
-    },
-    "keywords": [
-        "words",
-        "word",
-        "tiles",
-        "game",
-        "Wonderful",
-        "Word",
-        "Weaving"
-    ],
-    "author": "Craig McNaughton",
-    "license": "GPL-3.0-or-later",
-    "devDependencies": {
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "^9.39.4",
-        "@vitest/coverage-v8": "^4.1.5",
-        "eslint": "^9.39.4",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^7.2.1",
-        "globals": "^16.5.0",
-        "jsdom": "^29.1.1",
-        "sass": "^1.99.0",
-        "vite": "^8.0.10",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "tippy.js": "^6.3.7"
-    },
-    "browserslist": [
-        "last 2 versions"
-    ],
-    "packageManager": "yarn@4.14.1"
+  "name": "words",
+  "version": "1.4.0",
+  "description": "A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/).",
+  "scripts": {
+    "prepare": "husky",
+    "dev": "vite",
+    "build": "vite build",
+    "build:netlify": "vite build --mode netlify && node scripts/copy-netlify.mjs",
+    "preview": "vite preview --port 3080",
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/craigmcn/words.git"
+  },
+  "keywords": [
+    "words",
+    "word",
+    "tiles",
+    "game",
+    "Wonderful",
+    "Word",
+    "Weaving"
+  ],
+  "author": "Craig McNaughton",
+  "license": "GPL-3.0-or-later",
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^9.39.4",
+    "@vitest/coverage-v8": "^4.1.5",
+    "eslint": "^9.39.4",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^7.2.1",
+    "globals": "^16.5.0",
+    "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
+    "sass": "^1.99.0",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "tippy.js": "^6.3.7"
+  },
+  "browserslist": [
+    "last 2 versions"
+  ],
+  "packageManager": "yarn@4.14.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.1.1, ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -3836,6 +3845,7 @@ __metadata:
     eslint-plugin-node: "npm:^11.1.0"
     eslint-plugin-promise: "npm:^7.2.1"
     globals: "npm:^16.5.0"
+    husky: "npm:^9.1.7"
     jsdom: "npm:^29.1.1"
     sass: "npm:^1.99.0"
     tippy.js: "npm:^6.3.7"


### PR DESCRIPTION
## Summary

- Installs husky 9 as a devDependency
- Adds `"prepare": "husky"` script to `package.json`
- Creates `.husky/pre-commit` running `yarn lint && yarn test` on every commit
- Updates README Development section to mention the hook
- Updates CLAUDE.md Modernization status

## Test plan

- [ ] Make a test commit — hook should run lint + tests automatically
- [ ] `yarn lint` passes clean
- [ ] `yarn test` — 51/51 green