### PR TITLE
Rename vite.config.js → vite.config.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Vitest + jsdom. Test files live in `test/`. Run with `yarn test`.
 - **`test/toggle.test.js`** — header/footer and button-text toggles, localStorage persistence, `swapIcons`
 - **`test/keyboard.test.js`** — all `Ctrl+` shortcuts dispatch the correct function (modules mocked via `vi.mock`)
 
-Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environment: 'jsdom'`). No separate `babel.config.js` or `jest.config.js`.
+Vitest is configured in `vite.config.ts` (`test.globals: true`, `test.environment: 'jsdom'`). No separate `babel.config.js` or `jest.config.js`.
 
 ## Modernization status (2026-05-01)
 
@@ -77,7 +77,7 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 - **Node 24** — `.nvmrc` bumped from v22 → v24 (PR #52)
 - **Yarn 4** — switched from npm; `.yarnrc.yml` (node-modules linker); empty `yarn.lock` required to signal standalone project (parent dir has a Yarn workspace root)
 - **Vite 8** — replaced Gulp + Browserify + Babel; `root: src/`, `base: './'` for relative URLs under `/words/` sub-path
-- **Vitest 4** — replaced Jest + jest-environment-jsdom; config inline in `vite.config.js` (`globals: true`, `environment: jsdom`)
+- **Vitest 4** — replaced Jest + jest-environment-jsdom; config inline in `vite.config.ts` (`globals: true`, `environment: jsdom`)
 - **CI** — `test.yml` updated: `corepack enable` → `setup-node` with `cache: yarn` → `yarn install --immutable` → lint → build → `yarn coverage`
 - **Branch protection** — require PR, 1 approval, `enforce_admins: false` (owner bypass), require `test` status check, dismiss stale reviews, block force push + deletion
 
@@ -87,8 +87,10 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 - **CSS output** — Vite merges all CSS (albert.min.css + styles.scss + tippy.css) into a single `css/index.css`; sw.js updated accordingly
 - **Netlify copy** — `scripts/copy-netlify.mjs` copies individual entries from `netlify/` → `netlify/words/` (not the directory itself, to avoid self-copy error)
 
-### Nothing outstanding
-Modernization is complete. No open TODOs or blockers.
+### In progress
+- **ESLint indent** — switching 4-space → 2-space (PR #56)
+- **Husky** — pre-commit hooks (PR #57)
+- **vite.config.ts** — renamed from vite.config.js (PR #58)
 
 ---
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from 'vitest/config'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
+import type { Plugin } from 'vite'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-function serviceWorkerPlugin() {
+function serviceWorkerPlugin(): Plugin {
     return {
         name: 'service-worker',
         apply: 'build',
@@ -30,7 +31,7 @@ export default defineConfig(({ mode }) => ({
                 entryFileNames: 'js/[name].js',
                 chunkFileNames: 'js/[name].js',
                 assetFileNames: assetInfo =>
-                    /\.css$/i.test(assetInfo.name ?? '')
+                    /\.css$/i.test(assetInfo.names[0] ?? '')
                         ? 'css/[name][extname]'
                         : 'assets/[name][extname]',
             },


### PR DESCRIPTION
## Summary

- Renames `vite.config.js` → `vite.config.ts` for editor inference and cross-repo consistency
- Adds `import type { Plugin } from 'vite'` and `Plugin` return type on `serviceWorkerPlugin()`
- Fixes Rollup 4 deprecation surfaced by TypeScript: `assetInfo.name` → `assetInfo.names[0]`
- Updates CLAUDE.md references

## Test plan

- [ ] `yarn build` — clean output, no warnings
- [ ] `yarn test` — 51/51 green