### PR TITLE
Add Prettier; simplify ESLint to code-quality rules only

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+netlify/
+.yarn/
+src/styles/albert.min.css
+yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,47 +1,33 @@
 {
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
-    },
-    "editor.formatOnSave": false,
-    "[html]": {
-      "editor.formatOnSave": true,
-      "editor.defaultFormatter": "vscode.html-language-features"
-    },
-    "[css]": {
-      "editor.formatOnSave": true,
-    },
-    "[scss]": {
-      "editor.formatOnSave": true,
-    },
-    "css.validate": true,
-    "editor.detectIndentation": false,
-    "eslint.validate": [
-        "javascript"
-    ],
-    "files.eol": "\n",
-    "files.insertFinalNewline": true,
-    "beautify.language": {
-        "css": ["css", "scss"],
-    },
-    "cSpell.words": [
-        "buildtime",
-        "craigmcn",
-        "draggable",
-        "dragover",
-        "gulpfile",
-        "gulpif",
-        "msapplication",
-        "PRECACHE",
-        "STORAGEID"
-    ],
-    "cSpell.ignorePaths": [
-        "package-lock.json",
-        "node_modules",
-        "vscode-extension",
-        ".git/objects",
-        ".vscode",
-        ".vscode-insiders",
-        ".eslintrc.json",
-        "src/site.webmanifest"
-    ]
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "css.validate": true,
+  "editor.detectIndentation": false,
+  "eslint.validate": ["javascript"],
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "cSpell.words": [
+    "buildtime",
+    "craigmcn",
+    "draggable",
+    "dragover",
+    "gulpfile",
+    "gulpif",
+    "msapplication",
+    "PRECACHE",
+    "STORAGEID"
+  ],
+  "cSpell.ignorePaths": [
+    "package-lock.json",
+    "node_modules",
+    "vscode-extension",
+    ".git/objects",
+    ".vscode",
+    ".vscode-insiders",
+    ".eslintrc.json",
+    "src/site.webmanifest"
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ yarn dev             # Start Vite dev server at localhost:3080
 yarn build           # Build for production (output: ./dist)
 yarn build:netlify   # Build for Netlify deployment (output: ./netlify + ./netlify/words/)
 yarn preview         # Preview production build at localhost:3080
+yarn format          # Format all files with Prettier
+yarn format:check    # Check formatting (CI-safe, no writes)
 yarn lint            # Lint src and test JS files
 yarn lint:fix        # Lint and auto-fix src and test JS files
 yarn test            # Run Vitest test suite (single run)
@@ -74,6 +76,7 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 ## Modernization status (2026-05-01)
 
 ### Completed
+
 - **Node 24** — `.nvmrc` bumped from v22 → v24 (PR #52)
 - **Yarn 4** — switched from npm; `.yarnrc.yml` (node-modules linker); empty `yarn.lock` required to signal standalone project (parent dir has a Yarn workspace root)
 - **Vite 8** — replaced Gulp + Browserify + Babel; `root: src/`, `base: './'` for relative URLs under `/words/` sub-path
@@ -81,17 +84,22 @@ Vitest is configured in `vite.config.js` (`test.globals: true`, `test.environmen
 - **CI** — `test.yml` updated: `corepack enable` → `setup-node` with `cache: yarn` → `yarn install --immutable` → lint → build → `yarn coverage`
 - **Branch protection** — require PR, 1 approval, `enforce_admins: false` (owner bypass), require `test` status check, dismiss stale reviews, block force push + deletion
 
+### In progress
+
+- **ESLint indent** — switching 4-space → 2-space (PR #56)
+- **Husky** — pre-commit hooks: `yarn lint && yarn test` (PR #57)
+- **vite.config.ts** — renamed from vite.config.js; also fixes Rollup 4 `assetInfo.names` deprecation (PR #58)
+- **Prettier** — formatting for JS/HTML/CSS/SCSS; ESLint simplified to code-quality rules only (PR #59)
+
 ### Key decisions
+
 - **TypeScript: N/A** — intentionally vanilla JS PWA (same as `cryptogram`); not worth the migration cost for a game with no shared types
 - **Service worker** — hand-rolled `sw.js` (no workbox/vite-plugin-pwa); `{buildtime}` replaced via a custom Vite plugin in `generateBundle`; PRECACHE_URLS updated to merged `css/index.css` + `js/index.js`
 - **CSS output** — Vite merges all CSS (albert.min.css + styles.scss + tippy.css) into a single `css/index.css`; sw.js updated accordingly
 - **Netlify copy** — `scripts/copy-netlify.mjs` copies individual entries from `netlify/` → `netlify/words/` (not the directory itself, to avoid self-copy error)
 
-### Nothing outstanding
-Modernization is complete. No open TODOs or blockers.
-
 ---
 
 ### Code style
 
-ESLint enforces: single quotes, no semicolons, 4-space indent (`SwitchCase: 1`), trailing commas on multiline, `arrow-parens` only when required for block bodies.
+Prettier handles all formatting (JS, HTML, CSS/SCSS) with settings in `.prettierrc`: no semicolons, single quotes, 2-space indent, trailing commas. ESLint (`eslint.config.mjs`) is scoped to code-quality rules only — `no-console` warn, `js.configs.recommended`. Formatting rules have been removed from ESLint to avoid conflicts. Run `yarn format` to reformat; `yarn format:check` for CI.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ Your game is saved automatically. If you close the tab and come back, your grid 
 
 ## Controls
 
-| Button | Keyboard | Action |
-|---|---|---|
-| Roll the dice! | `Ctrl + Enter` | Roll new letters and start a fresh game |
-| Reset the grid | `Ctrl + Home` | Clear the grid (keeps the same letters) |
-| Add top row | `Ctrl + ↑` | Add a row above the grid |
-| Add bottom row | `Ctrl + ↓` | Add a row below the grid |
-| Add left column | `Ctrl + ←` | Add a column to the left of the grid |
-| Add right column | `Ctrl + →` | Add a column to the right of the grid |
-| Toggle header, footer | `Ctrl + Del` | Hide/show the header and footer for more space |
-| Toggle button text | `Ctrl + Space` | Switch the toolbar between text labels and icons only |
+| Button                | Keyboard       | Action                                                |
+| --------------------- | -------------- | ----------------------------------------------------- |
+| Roll the dice!        | `Ctrl + Enter` | Roll new letters and start a fresh game               |
+| Reset the grid        | `Ctrl + Home`  | Clear the grid (keeps the same letters)               |
+| Add top row           | `Ctrl + ↑`     | Add a row above the grid                              |
+| Add bottom row        | `Ctrl + ↓`     | Add a row below the grid                              |
+| Add left column       | `Ctrl + ←`     | Add a column to the left of the grid                  |
+| Add right column      | `Ctrl + →`     | Add a column to the right of the grid                 |
+| Toggle header, footer | `Ctrl + Del`   | Hide/show the header and footer for more space        |
+| Toggle button text    | `Ctrl + Space` | Switch the toolbar between text labels and icons only |
 
 The grid starts at 10×10. Add rows and columns as needed to fit longer words or more complex arrangements.
 
@@ -36,17 +36,19 @@ Words works in any modern browser and can be installed as an app. Look for the i
 
 ## Development
 
-**Stack:** Vanilla JS · Vite 8 · Sass · Vitest · ESLint · Yarn 4 · Node 24
+**Stack:** Vanilla JS · Vite 8 · Sass · Vitest · ESLint · Prettier · Yarn 4 · Node 24
 
 ```bash
-yarn dev        # Dev server at localhost:3080 (HMR)
-yarn build      # Production build → dist/
-yarn preview    # Preview production build at localhost:3080
-yarn lint       # Lint src and test files
-yarn lint:fix   # Lint and auto-fix
-yarn test       # Run test suite (single run)
-yarn test:watch # Run tests in watch mode
-yarn coverage   # Run tests with coverage report
+yarn dev           # Dev server at localhost:3080 (HMR)
+yarn build         # Production build → dist/
+yarn preview       # Preview production build at localhost:3080
+yarn format        # Format all files with Prettier
+yarn format:check  # Check formatting (no writes)
+yarn lint          # Lint src and test files
+yarn lint:fix      # Lint and auto-fix
+yarn test          # Run test suite (single run)
+yarn test:watch    # Run tests in watch mode
+yarn coverage      # Run tests with coverage report
 ```
 
 ## Testing

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,55 +1,31 @@
-import { defineConfig } from 'eslint/config'
 import globals from 'globals'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
+import eslintConfigPrettier from 'eslint-config-prettier'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all,
-})
-
-export default defineConfig([{
-    extends: compat.extends('eslint:recommended'),
-
+export default [
+  js.configs.recommended,
+  {
     languageOptions: {
-        globals: {
-            ...globals.browser,
-            ...globals.node,
-        },
-
-        ecmaVersion: 12,
-        sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      ecmaVersion: 12,
+      sourceType: 'module',
     },
-}, {
+  },
+  {
     files: ['test/**/*.js'],
-
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}, {
-
+  },
+  {
     rules: {
-        quotes: ['error', 'single'],
-        semi: ['error', 'never'],
-
-        indent: ['error', 4, {
-            SwitchCase: 1,
-        }],
-
-        'no-multi-spaces': ['error'],
-        'no-trailing-spaces': 'error',
-        'no-console': 'warn',
-        'comma-dangle': ['error', 'always-multiline'],
-
-        'arrow-parens': ['error', 'as-needed', {
-            requireForBlockBody: true,
-        }],
+      'no-console': 'warn',
     },
-}])
+  },
+  eslintConfigPrettier,
+]

--- a/package.json
+++ b/package.json
@@ -1,52 +1,52 @@
 {
-    "name": "words",
-    "version": "1.4.0",
-    "description": "A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/).",
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "build:netlify": "vite build --mode netlify && node scripts/copy-netlify.mjs",
-        "preview": "vite preview --port 3080",
-        "lint": "eslint src test",
-        "lint:fix": "eslint src test --fix",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "coverage": "vitest run --coverage"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/craigmcn/words.git"
-    },
-    "keywords": [
-        "words",
-        "word",
-        "tiles",
-        "game",
-        "Wonderful",
-        "Word",
-        "Weaving"
-    ],
-    "author": "Craig McNaughton",
-    "license": "GPL-3.0-or-later",
-    "devDependencies": {
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "^9.39.4",
-        "@vitest/coverage-v8": "^4.1.5",
-        "eslint": "^9.39.4",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^7.2.1",
-        "globals": "^16.5.0",
-        "jsdom": "^29.1.1",
-        "sass": "^1.99.0",
-        "vite": "^8.0.10",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "tippy.js": "^6.3.7"
-    },
-    "browserslist": [
-        "last 2 versions"
-    ],
-    "packageManager": "yarn@4.14.1"
+  "name": "words",
+  "version": "1.4.0",
+  "description": "A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/).",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:netlify": "vite build --mode netlify && node scripts/copy-netlify.mjs",
+    "preview": "vite preview --port 3080",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/craigmcn/words.git"
+  },
+  "keywords": [
+    "words",
+    "word",
+    "tiles",
+    "game",
+    "Wonderful",
+    "Word",
+    "Weaving"
+  ],
+  "author": "Craig McNaughton",
+  "license": "GPL-3.0-or-later",
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@vitest/coverage-v8": "^4.1.5",
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
+    "prettier": "^3.8.3",
+    "sass": "^1.99.0",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "tippy.js": "^6.3.7"
+  },
+  "browserslist": [
+    "last 2 versions"
+  ],
+  "packageManager": "yarn@4.14.1"
 }

--- a/scripts/copy-netlify.mjs
+++ b/scripts/copy-netlify.mjs
@@ -2,6 +2,6 @@ import { cpSync, mkdirSync, readdirSync } from 'fs'
 
 mkdirSync('netlify/words', { recursive: true })
 for (const entry of readdirSync('netlify')) {
-    if (entry === 'words') continue
-    cpSync(`netlify/${entry}`, `netlify/words/${entry}`, { recursive: true })
+  if (entry === 'words') continue
+  cpSync(`netlify/${entry}`, `netlify/words/${entry}`, { recursive: true })
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,405 +1,578 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Words</title>
 
-    <meta name="description"
-        content="A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/).">
+    <meta
+      name="description"
+      content="A word tile game based on Wonderful Word Weaving (http://wonderfulwordweaving.com/)."
+    />
 
     <script>
-        (() => !window.location.pathname.endsWith("/") && window.location.replace(window.location.href + "/"))()
+      ;(() =>
+        !window.location.pathname.endsWith('/') &&
+        window.location.replace(window.location.href + '/'))()
     </script>
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=eEvolvQr5k">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=eEvolvQr5k">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=eEvolvQr5k">
-    <link rel="manifest" href="./site.webmanifest?v=eEvolvQr5k">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg?v=eEvolvQr5k" color="#005b99">
-    <link rel="shortcut icon" href="/favicon.ico?v=eEvolvQr5k">
-    <meta name="msapplication-TileColor" content="#005b99">
-    <meta name="theme-color" content="#005b99">
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/apple-touch-icon.png?v=eEvolvQr5k"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/favicon-32x32.png?v=eEvolvQr5k"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/favicon-16x16.png?v=eEvolvQr5k"
+    />
+    <link rel="manifest" href="./site.webmanifest?v=eEvolvQr5k" />
+    <link
+      rel="mask-icon"
+      href="/safari-pinned-tab.svg?v=eEvolvQr5k"
+      color="#005b99"
+    />
+    <link rel="shortcut icon" href="/favicon.ico?v=eEvolvQr5k" />
+    <meta name="msapplication-TileColor" content="#005b99" />
+    <meta name="theme-color" content="#005b99" />
 
-    <link rel="stylesheet" href="./styles/albert.min.css">
-    <link rel="stylesheet" href="./styles/styles.scss">
-</head>
+    <link rel="stylesheet" href="./styles/albert.min.css" />
+    <link rel="stylesheet" href="./styles/styles.scss" />
+  </head>
 
-<body>
-
+  <body>
     <header id="header" class="header">
-        <div class="brand">
-            <a href="/">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="40">
-                    <rect class="np__bg" x="0" width="512" height="512" rx="51.2" />
-                    <path class="np__txt"
-                        d="M507.1 334.5c0 -12.2 -0.9 -24.2 -4 -36c-4.5 -16.9 -14 -30.2 -30.2 -37.2c-13.4 -5.8 -27.9 -5.8 -42.1 -3.2c-19.7 3.6 -36.9 12.2 -49.7 28.3c-2.2 2.8 -4.3 5.6 -6.5 8.3c-0.4 -0.4 -0.8 -0.6 -0.9 -0.9c-0.3 -0.6 -0.4 -1.2 -0.6 -1.8c-5.3 -16.2 -16.3 -27 -32.3 -32c-17.9 -5.5 -36 -4 -53.6 1.5c-17.7 5.5 -32.5 15.5 -43 31.8c0 -9.4 -0.1 -18.9 0.1 -28.4c0.1 -3.3 -0.9 -4.1 -4.2 -4.1c-15.5 0.2 -31 0.2 -46.5 0c-4 -0.1 -4.5 1.2 -4.5 4.8c0.1 63.8 0.1 127.6 0 191.4c0 3.7 0.6 5.1 4.8 5c17.2 -0.3 34.3 -0.2 51.5 0c3.9 0.1 4.9 -0.9 4.9 -4.9l-0.1 -106.4c0 -2.1 0.3 -4.1 1.1 -6.2c3.6 -10.1 9.8 -18.1 17.9 -25.1c9.5 -8.2 25.2 -10.9 34.5 -5.3c10.3 6.3 13.4 16.7 13.5 27.7c0.3 38.3 0.2 76.6 0 114.9c0 4 0.7 5.4 5 5.3c17.3 -0.3 34.6 -0.3 52 0c4.1 0.1 5.2 -0.9 5.2 -5.1c-0.2 -36 -0.1 -71.9 -0.1 -107.9c0 -1.6 -0.2 -3.5 0.5 -4.9c5.8 -12.9 13.8 -24 27.2 -30.1c15.5 -7 29 -1.2 34.8 11.2c3.5 7.5 4.3 15.7 4.4 23.9c0.2 35.8 0.2 71.6 0 107.4c0 4.8 1.5 5.6 5.8 5.5c16.8 -0.2 33.7 -0.2 50.5 0c3.8 0 5 -0.8 5 -4.8C507 416.1 507.1 375.3 507.1 334.5z" />
-                    <path class="np__txt"
-                        d="M161.3 411.2c-2 4.7 -4.8 9.1 -8.6 12.3c-16.4 13.6 -34.6 21.3 -56.6 18.4c-13.6 -1.8 -25.6 -6.9 -35.5 -15.6c-23.9 -21 -32.3 -48.3 -28 -79.1c2.6 -18.9 11 -35.4 25.9 -48.2c11.5 -9.8 24.6 -15.7 39.5 -17c13.6 -1.2 26.7 1.2 38.8 8.1c10.3 5.9 18.6 13.8 24.2 24.4c8.2 -2.6 16.7 -5.2 25.4 -8c-5.4 -11.5 -16.8 -24.6 -27.2 -31.6c-25.2 -17.1 -52.9 -19.6 -81.5 -12.4c-19.3 4.8 -35.6 15.4 -48.5 31c-14.3 17.3 -21.7 37.2 -23.7 59.1c-1.1 12 -0.2 24 2.9 35.8c6.5 25 19.8 45.4 41 60c20.2 13.9 42.6 19.5 67.2 16.7c15.2 -1.7 29.2 -6.1 42 -14.2c13.4 -8.4 23.7 -19.6 29.9 -34.5c-7.8 -2.2 -15.3 -4.1 -22.6 -6.7C163 408.4 162.1 409.3 161.3 411.2z" />
-                </svg>
-                craigmcn
-            </a>
-        </div>
-        <h1>Words</h1>
+      <div class="brand">
+        <a href="/">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+            width="40"
+          >
+            <rect class="np__bg" x="0" width="512" height="512" rx="51.2" />
+            <path
+              class="np__txt"
+              d="M507.1 334.5c0 -12.2 -0.9 -24.2 -4 -36c-4.5 -16.9 -14 -30.2 -30.2 -37.2c-13.4 -5.8 -27.9 -5.8 -42.1 -3.2c-19.7 3.6 -36.9 12.2 -49.7 28.3c-2.2 2.8 -4.3 5.6 -6.5 8.3c-0.4 -0.4 -0.8 -0.6 -0.9 -0.9c-0.3 -0.6 -0.4 -1.2 -0.6 -1.8c-5.3 -16.2 -16.3 -27 -32.3 -32c-17.9 -5.5 -36 -4 -53.6 1.5c-17.7 5.5 -32.5 15.5 -43 31.8c0 -9.4 -0.1 -18.9 0.1 -28.4c0.1 -3.3 -0.9 -4.1 -4.2 -4.1c-15.5 0.2 -31 0.2 -46.5 0c-4 -0.1 -4.5 1.2 -4.5 4.8c0.1 63.8 0.1 127.6 0 191.4c0 3.7 0.6 5.1 4.8 5c17.2 -0.3 34.3 -0.2 51.5 0c3.9 0.1 4.9 -0.9 4.9 -4.9l-0.1 -106.4c0 -2.1 0.3 -4.1 1.1 -6.2c3.6 -10.1 9.8 -18.1 17.9 -25.1c9.5 -8.2 25.2 -10.9 34.5 -5.3c10.3 6.3 13.4 16.7 13.5 27.7c0.3 38.3 0.2 76.6 0 114.9c0 4 0.7 5.4 5 5.3c17.3 -0.3 34.6 -0.3 52 0c4.1 0.1 5.2 -0.9 5.2 -5.1c-0.2 -36 -0.1 -71.9 -0.1 -107.9c0 -1.6 -0.2 -3.5 0.5 -4.9c5.8 -12.9 13.8 -24 27.2 -30.1c15.5 -7 29 -1.2 34.8 11.2c3.5 7.5 4.3 15.7 4.4 23.9c0.2 35.8 0.2 71.6 0 107.4c0 4.8 1.5 5.6 5.8 5.5c16.8 -0.2 33.7 -0.2 50.5 0c3.8 0 5 -0.8 5 -4.8C507 416.1 507.1 375.3 507.1 334.5z"
+            />
+            <path
+              class="np__txt"
+              d="M161.3 411.2c-2 4.7 -4.8 9.1 -8.6 12.3c-16.4 13.6 -34.6 21.3 -56.6 18.4c-13.6 -1.8 -25.6 -6.9 -35.5 -15.6c-23.9 -21 -32.3 -48.3 -28 -79.1c2.6 -18.9 11 -35.4 25.9 -48.2c11.5 -9.8 24.6 -15.7 39.5 -17c13.6 -1.2 26.7 1.2 38.8 8.1c10.3 5.9 18.6 13.8 24.2 24.4c8.2 -2.6 16.7 -5.2 25.4 -8c-5.4 -11.5 -16.8 -24.6 -27.2 -31.6c-25.2 -17.1 -52.9 -19.6 -81.5 -12.4c-19.3 4.8 -35.6 15.4 -48.5 31c-14.3 17.3 -21.7 37.2 -23.7 59.1c-1.1 12 -0.2 24 2.9 35.8c6.5 25 19.8 45.4 41 60c20.2 13.9 42.6 19.5 67.2 16.7c15.2 -1.7 29.2 -6.1 42 -14.2c13.4 -8.4 23.7 -19.6 29.9 -34.5c-7.8 -2.2 -15.3 -4.1 -22.6 -6.7C163 408.4 162.1 409.3 161.3 411.2z"
+            />
+          </svg>
+          craigmcn
+        </a>
+      </div>
+      <h1>Words</h1>
     </header>
 
     <noscript>
-        <div class="alert alert--danger alert--overlay" role="alert">
-            <div class="alert__icon p-t-xs" aria-hidden="true">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 576 512" style="font-size: 2em;">
-                    <path fill="currentColor"
-                        d="M248.747 204.705l6.588 112c.373 6.343 5.626 11.295 11.979 11.295h41.37a12 12 0 0 0 11.979-11.295l6.588-112c.405-6.893-5.075-12.705-11.979-12.705h-54.547c-6.903 0-12.383 5.812-11.978 12.705zM330 384c0 23.196-18.804 42-42 42s-42-18.804-42-42 18.804-42 42-42 42 18.804 42 42zm-.423-360.015c-18.433-31.951-64.687-32.009-83.154 0L6.477 440.013C-11.945 471.946 11.118 512 48.054 512H527.94c36.865 0 60.035-39.993 41.577-71.987L329.577 23.985zM53.191 455.002L282.803 57.008c2.309-4.002 8.085-4.002 10.394 0l229.612 397.993c2.308 4-.579 8.998-5.197 8.998H58.388c-4.617.001-7.504-4.997-5.197-8.997z">
-                    </path>
-                </svg>
-            </div>
-            <div class="alert__text">This game does not work without Javascript enabled.</div>
+      <div class="alert alert--danger alert--overlay" role="alert">
+        <div class="alert__icon p-t-xs" aria-hidden="true">
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 576 512"
+            style="font-size: 2em"
+          >
+            <path
+              fill="currentColor"
+              d="M248.747 204.705l6.588 112c.373 6.343 5.626 11.295 11.979 11.295h41.37a12 12 0 0 0 11.979-11.295l6.588-112c.405-6.893-5.075-12.705-11.979-12.705h-54.547c-6.903 0-12.383 5.812-11.978 12.705zM330 384c0 23.196-18.804 42-42 42s-42-18.804-42-42 18.804-42 42-42 42 18.804 42 42zm-.423-360.015c-18.433-31.951-64.687-32.009-83.154 0L6.477 440.013C-11.945 471.946 11.118 512 48.054 512H527.94c36.865 0 60.035-39.993 41.577-71.987L329.577 23.985zM53.191 455.002L282.803 57.008c2.309-4.002 8.085-4.002 10.394 0l229.612 397.993c2.308 4-.579 8.998-5.197 8.998H58.388c-4.617.001-7.504-4.997-5.197-8.997z"
+            ></path>
+          </svg>
         </div>
+        <div class="alert__text">
+          This game does not work without Javascript enabled.
+        </div>
+      </div>
     </noscript>
 
     <main class="main flex flex--jc-center">
+      <section class="controls">
+        <!-- Button SVG icons are from Font Awesome 5, replaced to avoid added JS and HTTP requests -->
+        <button
+          id="roll"
+          class="button button--danger m-b-xl"
+          type="button"
+          data-tippy-content="Roll the dice! (Ctrl + Enter)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M488.6 250.2L392 214V105.52a36 36 0 0 0-23.4-33.7l-100-37.5a35.68 35.68 0 0 0-25.3 0l-100 37.5a36 36 0 0 0-23.4 33.7V214l-96.6 36.2A36 36 0 0 0 0 283.9V394a36 36 0 0 0 19.9 32.2l100 50a35.86 35.86 0 0 0 32.2 0l103.9-52 103.9 52a35.86 35.86 0 0 0 32.2 0l100-50A36 36 0 0 0 512 394V283.9a36 36 0 0 0-23.4-33.7zM238 395.18l-85 42.5v-79.09l85-38.8zm0-112l-102 41.41L34 283.2v-.6l102-38.2 102 38.2zm-84-178.46v-.6l102-38.2 102 38.2v.6l-102 41.39zm119 73.79l85-37v73.29l-85 31.9zm205 216.67l-85 42.5v-79.09l85-38.8zm0-112l-102 41.41-102-41.39v-.6l102-38.2 102 38.2z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M153 437.68l85-42.5v-75.39l-85 38.8zm240-79.09v79.09l85-42.5v-75.39zM273 246.7l85-31.9v-73.29l-85 37z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Roll the dice!</span>
+        </button>
 
-        <section class="controls">
-            <!-- Button SVG icons are from Font Awesome 5, replaced to avoid added JS and HTTP requests -->
-            <button id="roll" class="button button--danger m-b-xl" type="button"
-                data-tippy-content="Roll the dice! (Ctrl + Enter)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 512 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M488.6 250.2L392 214V105.52a36 36 0 0 0-23.4-33.7l-100-37.5a35.68 35.68 0 0 0-25.3 0l-100 37.5a36 36 0 0 0-23.4 33.7V214l-96.6 36.2A36 36 0 0 0 0 283.9V394a36 36 0 0 0 19.9 32.2l100 50a35.86 35.86 0 0 0 32.2 0l103.9-52 103.9 52a35.86 35.86 0 0 0 32.2 0l100-50A36 36 0 0 0 512 394V283.9a36 36 0 0 0-23.4-33.7zM238 395.18l-85 42.5v-79.09l85-38.8zm0-112l-102 41.41L34 283.2v-.6l102-38.2 102 38.2zm-84-178.46v-.6l102-38.2 102 38.2v.6l-102 41.39zm119 73.79l85-37v73.29l-85 31.9zm205 216.67l-85 42.5v-79.09l85-38.8zm0-112l-102 41.41-102-41.39v-.6l102-38.2 102 38.2z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M153 437.68l85-42.5v-75.39l-85 38.8zm240-79.09v79.09l85-42.5v-75.39zM273 246.7l85-31.9v-73.29l-85 37z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Roll the dice!</span>
-            </button>
+        <button
+          id="reset"
+          class="button button--secondary"
+          type="button"
+          data-tippy-content="Reset the grid (Ctrl + Home)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M129 383a12 12 0 0 1 16.37-.56A166.77 166.77 0 0 0 256 424c93.82 0 167.24-76 168-166.55C424.79 162 346.91 87.21 254.51 88a166.73 166.73 0 0 0-113.2 45.25L84.69 76.69A247.12 247.12 0 0 1 255.54 8C392.35 7.76 504 119.19 504 256c0 137-111 248-248 248a247.11 247.11 0 0 1-166.18-63.91l-.49-.46a12 12 0 0 1 0-17z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M49 41l134.06 134c15.09 15.15 4.38 41-17 41H32a24 24 0 0 1-24-24V57.94C8 36.56 33.85 25.85 49 41z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Reset the grid</span>
+        </button>
 
-            <button id="reset" class="button button--secondary" type="button"
-                data-tippy-content="Reset the grid (Ctrl + Home)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 512 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M129 383a12 12 0 0 1 16.37-.56A166.77 166.77 0 0 0 256 424c93.82 0 167.24-76 168-166.55C424.79 162 346.91 87.21 254.51 88a166.73 166.73 0 0 0-113.2 45.25L84.69 76.69A247.12 247.12 0 0 1 255.54 8C392.35 7.76 504 119.19 504 256c0 137-111 248-248 248a247.11 247.11 0 0 1-166.18-63.91l-.49-.46a12 12 0 0 1 0-17z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M49 41l134.06 134c15.09 15.15 4.38 41-17 41H32a24 24 0 0 1-24-24V57.94C8 36.56 33.85 25.85 49 41z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Reset the grid</span>
-            </button>
+        <button
+          id="addRowTop"
+          class="button"
+          type="button"
+          data-tippy-content="Add top row (Ctrl + Arrow up)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 384 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M24 32h336a23.94 23.94 0 0 1 24 24v16a23.94 23.94 0 0 1-24 24H24A23.94 23.94 0 0 1 0 72V56a23.94 23.94 0 0 1 24-24z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M56.13 321.48l-17.06-17a23.86 23.86 0 0 1 0-33.91L175 135.05a24 24 0 0 1 34 0l135.93 135.52a23.86 23.86 0 0 1 0 33.91l-17.06 17a24 24 0 0 1-34 0l-65.81-65.61V456A24 24 0 0 1 204 480h-24.09a24 24 0 0 1-24.07-24V255.87L90 321.48a23.9 23.9 0 0 1-33.87 0z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Add top row</span>
+        </button>
 
-            <button id="addRowTop" class="button" type="button" data-tippy-content="Add top row (Ctrl + Arrow up)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 384 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M24 32h336a23.94 23.94 0 0 1 24 24v16a23.94 23.94 0 0 1-24 24H24A23.94 23.94 0 0 1 0 72V56a23.94 23.94 0 0 1 24-24z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M56.13 321.48l-17.06-17a23.86 23.86 0 0 1 0-33.91L175 135.05a24 24 0 0 1 34 0l135.93 135.52a23.86 23.86 0 0 1 0 33.91l-17.06 17a24 24 0 0 1-34 0l-65.81-65.61V456A24 24 0 0 1 204 480h-24.09a24 24 0 0 1-24.07-24V255.87L90 321.48a23.9 23.9 0 0 1-33.87 0z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Add top row</span>
-            </button>
+        <button
+          id="addRowBottom"
+          class="button"
+          type="button"
+          data-tippy-content="Add bottom row (Ctrl + Arrow down)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 384 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M360 480H24a23.94 23.94 0 0 1-24-23.88V440a23.94 23.94 0 0 1 23.88-24H360a23.94 23.94 0 0 1 24 23.88V456a23.94 23.94 0 0 1-23.88 24z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M327.87 190.52l17.06 17a23.86 23.86 0 0 1 .17 33.74l-.17.17L209 377a24 24 0 0 1-33.94.06L175 377 39.07 241.43a23.86 23.86 0 0 1-.17-33.74l.17-.17 17.06-17a24 24 0 0 1 33.94-.06l.06.06 65.81 65.61V56a24 24 0 0 1 24-24h24.14a24 24 0 0 1 24.07 23.93v200.2L294 190.52a23.91 23.91 0 0 1 33.8-.07z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Add bottom row</span>
+        </button>
 
-            <button id="addRowBottom" class="button" type="button"
-                data-tippy-content="Add bottom row (Ctrl + Arrow down)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 384 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M360 480H24a23.94 23.94 0 0 1-24-23.88V440a23.94 23.94 0 0 1 23.88-24H360a23.94 23.94 0 0 1 24 23.88V456a23.94 23.94 0 0 1-23.88 24z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M327.87 190.52l17.06 17a23.86 23.86 0 0 1 .17 33.74l-.17.17L209 377a24 24 0 0 1-33.94.06L175 377 39.07 241.43a23.86 23.86 0 0 1-.17-33.74l.17-.17 17.06-17a24 24 0 0 1 33.94-.06l.06.06 65.81 65.61V56a24 24 0 0 1 24-24h24.14a24 24 0 0 1 24.07 23.93v200.2L294 190.52a23.91 23.91 0 0 1 33.8-.07z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Add bottom row</span>
-            </button>
+        <button
+          id="addColumnLeft"
+          class="button"
+          type="button"
+          data-tippy-content="Add left column (Ctrl + Arrow left)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M0 424V88a23.94 23.94 0 0 1 24-24h16a23.94 23.94 0 0 1 24 24v336a23.94 23.94 0 0 1-24 24H24a23.94 23.94 0 0 1-24-24z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M289.48 391.87l-17 17.06a23.86 23.86 0 0 1-33.91 0L103.05 273a24 24 0 0 1 0-34l135.52-135.93a23.86 23.86 0 0 1 33.91 0l17 17.06a24 24 0 0 1 0 34l-65.61 65.81H424A24 24 0 0 1 448 244v24.08a24 24 0 0 1-24 24.07H223.87L289.48 358a23.9 23.9 0 0 1 0 33.87z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Add left column</span>
+        </button>
 
-            <button id="addColumnLeft" class="button" type="button"
-                data-tippy-content="Add left column (Ctrl + Arrow left)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M0 424V88a23.94 23.94 0 0 1 24-24h16a23.94 23.94 0 0 1 24 24v336a23.94 23.94 0 0 1-24 24H24a23.94 23.94 0 0 1-24-24z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M289.48 391.87l-17 17.06a23.86 23.86 0 0 1-33.91 0L103.05 273a24 24 0 0 1 0-34l135.52-135.93a23.86 23.86 0 0 1 33.91 0l17 17.06a24 24 0 0 1 0 34l-65.61 65.81H424A24 24 0 0 1 448 244v24.08a24 24 0 0 1-24 24.07H223.87L289.48 358a23.9 23.9 0 0 1 0 33.87z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Add left column</span>
-            </button>
+        <button
+          id="addColumnRight"
+          class="button"
+          type="button"
+          data-tippy-content="Add right column (Ctrl + Arrow right)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M448 88v336a23.94 23.94 0 0 1-24 24h-16a23.94 23.94 0 0 1-24-24V88a23.94 23.94 0 0 1 24-24h16a23.94 23.94 0 0 1 24 24z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M158.52 120.13l17-17.06a23.86 23.86 0 0 1 33.91 0L345 239a24 24 0 0 1 0 34L209.43 408.93a23.86 23.86 0 0 1-33.91 0l-17-17.06a24 24 0 0 1 0-34l65.61-65.81H24A24 24 0 0 1 0 268v-24.09a24 24 0 0 1 24-24.07h200.13L158.52 154a23.9 23.9 0 0 1 0-33.87z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Add right column</span>
+        </button>
 
-            <button id="addColumnRight" class="button" type="button"
-                data-tippy-content="Add right column (Ctrl + Arrow right)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M448 88v336a23.94 23.94 0 0 1-24 24h-16a23.94 23.94 0 0 1-24-24V88a23.94 23.94 0 0 1 24-24h16a23.94 23.94 0 0 1 24 24z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M158.52 120.13l17-17.06a23.86 23.86 0 0 1 33.91 0L345 239a24 24 0 0 1 0 34L209.43 408.93a23.86 23.86 0 0 1-33.91 0l-17-17.06a24 24 0 0 1 0-34l65.61-65.81H24A24 24 0 0 1 0 268v-24.09a24 24 0 0 1 24-24.07h200.13L158.52 154a23.9 23.9 0 0 1 0-33.87z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Add right column</span>
-            </button>
+        <button
+          id="toggleHeaderFooter"
+          class="button"
+          type="button"
+          data-tippy-content="Toggle header, footer (Ctrl + Del)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M436 128h-84V44a12 12 0 0 0-12-12h-40a12 12 0 0 0-12 12v124a23.94 23.94 0 0 0 24 24h124a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM136 320H12a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h84v84a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V344a23.94 23.94 0 0 0-24-24z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M436 320H312a23.94 23.94 0 0 0-24 24v124a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12v-84h84a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM148 32h-40a12 12 0 0 0-12 12v84H12a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h124a23.94 23.94 0 0 0 24-24V44a12 12 0 0 0-12-12z"
+              ></path>
+            </g>
+          </svg>
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+            hidden
+          >
+            <g>
+              <path
+                fill="currentColor"
+                opacity="0.4"
+                d="M148 32H24A23.94 23.94 0 0 0 0 56v124a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V96h84a12 12 0 0 0 12-12V44a12 12 0 0 0-12-12zm288 288h-40a12 12 0 0 0-12 12v84h-84a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h124a23.94 23.94 0 0 0 24-24V332a12 12 0 0 0-12-12z"
+              ></path>
+              <path
+                fill="currentColor"
+                d="M148 416H64v-84a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12v124a23.94 23.94 0 0 0 24 24h124a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM424 32H300a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h84v84a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V56a23.94 23.94 0 0 0-24-24z"
+              ></path>
+            </g>
+          </svg>
+          <span class="js-canHide"> Toggle header, footer</span>
+        </button>
 
-            <button id="toggleHeaderFooter" class="button" type="button"
-                data-tippy-content="Toggle header, footer (Ctrl + Del)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512">
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M436 128h-84V44a12 12 0 0 0-12-12h-40a12 12 0 0 0-12 12v124a23.94 23.94 0 0 0 24 24h124a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM136 320H12a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h84v84a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V344a23.94 23.94 0 0 0-24-24z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M436 320H312a23.94 23.94 0 0 0-24 24v124a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12v-84h84a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM148 32h-40a12 12 0 0 0-12 12v84H12a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h124a23.94 23.94 0 0 0 24-24V44a12 12 0 0 0-12-12z">
-                        </path>
-                    </g>
-                </svg>
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512" hidden>
-                    <g>
-                        <path fill="currentColor" opacity="0.4"
-                            d="M148 32H24A23.94 23.94 0 0 0 0 56v124a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V96h84a12 12 0 0 0 12-12V44a12 12 0 0 0-12-12zm288 288h-40a12 12 0 0 0-12 12v84h-84a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h124a23.94 23.94 0 0 0 24-24V332a12 12 0 0 0-12-12z">
-                        </path>
-                        <path fill="currentColor"
-                            d="M148 416H64v-84a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12v124a23.94 23.94 0 0 0 24 24h124a12 12 0 0 0 12-12v-40a12 12 0 0 0-12-12zM424 32H300a12 12 0 0 0-12 12v40a12 12 0 0 0 12 12h84v84a12 12 0 0 0 12 12h40a12 12 0 0 0 12-12V56a23.94 23.94 0 0 0-24-24z">
-                        </path>
-                    </g>
-                </svg>
-                <span class="js-canHide"> Toggle header, footer</span>
-            </button>
+        <button
+          id="toggleButtonText"
+          class="button"
+          type="button"
+          data-tippy-content="Toggle button text (Ctrl + Space)"
+        >
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+          >
+            <path
+              fill="currentColor"
+              d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            ></path>
+          </svg>
+          <svg
+            class="icon"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 448 512"
+            hidden
+          >
+            <path
+              fill="currentColor"
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            ></path>
+          </svg>
+          <span class="js-canHide"> Toggle button text</span>
+        </button>
+      </section>
 
-            <button id="toggleButtonText" class="button" type="button"
-                data-tippy-content="Toggle button text (Ctrl + Space)">
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512">
-                    <path fill="currentColor"
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z">
-                    </path>
-                </svg>
-                <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 448 512" hidden>
-                    <path fill="currentColor"
-                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z">
-                    </path>
-                </svg>
-                <span class="js-canHide"> Toggle button text</span>
-            </button>
+      <section id="letters" class="letters m-l-sm">
+        <ul id="letters__list" class="letters__list">
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+          <li class="letters__item"></li>
+        </ul>
+      </section>
 
-        </section>
-
-        <section id="letters" class="letters m-l-sm">
-
-            <ul id="letters__list" class="letters__list">
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-                <li class="letters__item"></li>
-            </ul>
-
-        </section>
-
-        <section id="words" class="words">
-
-            <table id="words__grid" class="words__grid">
-                <tbody>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                    <tr>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                        <td class="words__cell"></td>
-                    </tr>
-                </tbody>
-            </table>
-
-        </section>
-
+      <section id="words" class="words">
+        <table id="words__grid" class="words__grid">
+          <tbody>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+            <tr>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+              <td class="words__cell"></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </main>
 
-    <div id="notification" class="alert alert--info alert--overlay" role="alert" hidden>
-        <div class="alert__icon p-t-xs" aria-hidden="true">
-            <svg class="icon" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 512 512" style="font-size: 2em;">
-                <path fill="currentColor"
-                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm0-338c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z">
-                </path>
-            </svg>
-        </div>
-        <div class="alert__text">A new version is available.
-            <button id="reload" class="button button--info button--sm m-t-0 m-l-md">Reload</button>
-        </div>
+    <div
+      id="notification"
+      class="alert alert--info alert--overlay"
+      role="alert"
+      hidden
+    >
+      <div class="alert__icon p-t-xs" aria-hidden="true">
+        <svg
+          class="icon"
+          aria-hidden="true"
+          focusable="false"
+          role="img"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          style="font-size: 2em"
+        >
+          <path
+            fill="currentColor"
+            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm0-338c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+          ></path>
+        </svg>
+      </div>
+      <div class="alert__text">
+        A new version is available.
+        <button id="reload" class="button button--info button--sm m-t-0 m-l-md">
+          Reload
+        </button>
+      </div>
     </div>
 
     <footer id="footer">
-        <p>Game play idea and letter dice values from <a href="http://wonderfulwordweaving.com/">Wonderful Word
-                Weaving</a>.</p>
-        <ul>
-            <li>Drag letters onto the grid to spell words, horizontally or vertically.</li>
-            <li>Drag letters off the grid to remove them.</li>
-            <li>Dragging a letter onto an occupied grid cell will return the previous letter to the list.</li>
-        </ul>
+      <p>
+        Game play idea and letter dice values from
+        <a href="http://wonderfulwordweaving.com/">Wonderful Word Weaving</a>.
+      </p>
+      <ul>
+        <li>
+          Drag letters onto the grid to spell words, horizontally or vertically.
+        </li>
+        <li>Drag letters off the grid to remove them.</li>
+        <li>
+          Dragging a letter onto an occupied grid cell will return the previous
+          letter to the list.
+        </li>
+      </ul>
     </footer>
 
     <script type="module" src="./scripts/index.js"></script>
-
-</body>
-
+  </body>
 </html>

--- a/src/scripts/cleanup.js
+++ b/src/scripts/cleanup.js
@@ -1,5 +1,5 @@
 // cleanup old stored data
 export const cleanup = () => {
-    window.localStorage.removeItem('craigmcn-words-compress')
-    window.localStorage.removeItem('craigmcn-words-icons-only')
+  window.localStorage.removeItem('craigmcn-words-compress')
+  window.localStorage.removeItem('craigmcn-words-icons-only')
 }

--- a/src/scripts/dragDrop.js
+++ b/src/scripts/dragDrop.js
@@ -1,189 +1,182 @@
-import {
-    setComplete,
-} from './game'
-import {
-    $letters,
-    updateLetter,
-} from './letters'
-import {
-    updateGrid,
-} from './grid'
+import { setComplete } from './game'
+import { $letters, updateLetter } from './letters'
+import { updateGrid } from './grid'
 
 /* Dragging and Dropping */
 let dragSource, dropTarget
 
-const getDragSource = el =>
-    el.classList.contains('words__cell') ? el : el.closest('ul')
+const getDragSource = (el) =>
+  el.classList.contains('words__cell') ? el : el.closest('ul')
 const getDropTarget = getDragSource
-const isDropTarget = el =>
-    el.classList.contains('words__cell') || !!el.closest('ul')
+const isDropTarget = (el) =>
+  el.classList.contains('words__cell') || !!el.closest('ul')
 
 const handleDragStart = (e) => {
-    // console.log('handleDragStart', e)
-    const el = e.target
-    if (el.draggable) {
-        dragSource = getDragSource(el)
-        dragSource.dataset.transfer = el.dataset.value
+  // console.log('handleDragStart', e)
+  const el = e.target
+  if (el.draggable) {
+    dragSource = getDragSource(el)
+    dragSource.dataset.transfer = el.dataset.value
+  }
+  const touch = e.targetTouches
+  if (el.dataset) {
+    if (touch) {
+      const touchLocation = touch[0]
+      el.dataset.pageX = touchLocation.pageX - window.scrollX
+      el.dataset.pageY = touchLocation.pageY - window.scrollY
+    } else {
+      el.dataset.pageX = e.x
+      el.dataset.pageY = e.y
     }
-    const touch = e.targetTouches
-    if (el.dataset) {
-        if (touch) {
-            const touchLocation = touch[0]
-            el.dataset.pageX = touchLocation.pageX - window.scrollX
-            el.dataset.pageY = touchLocation.pageY - window.scrollY
-        } else {
-            el.dataset.pageX = e.x
-            el.dataset.pageY = e.y
-        }
-    }
+  }
 }
 
 const handleDragEnd = (e) => {
-    // console.log('handleDragEnd', e)
-    if (e.dataTransfer.dropEffect !== 'none' && dropTarget !== dragSource) {
-        handleDropEffect(e.target)
-    }
-    clearDragOver()
+  // console.log('handleDragEnd', e)
+  if (e.dataTransfer.dropEffect !== 'none' && dropTarget !== dragSource) {
+    handleDropEffect(e.target)
+  }
+  clearDragOver()
 }
 
 const handleDropEffect = (el) => {
-    // console.log('handleDropEffect', el)
-    dragSource && dragSource.removeAttribute('data-transfer')
-    if (el && el.classList.contains('letters__item')) {
-        el.classList.add('used')
-        el.draggable = false
-        setComplete($letters)
-        updateLetter(el.dataset.value, true)
-    } else if (el && el.classList.contains('words__cell')) {
-        el.innerText = ''
-        el.removeAttribute('data-value')
-        el.removeAttribute('draggable')
-        el.classList.remove('used')
-        removeDragging(el)
-        updateGrid('', el.dataset.row, el.dataset.col)
-    }
-    el.removeAttribute('data-page-x')
-    el.removeAttribute('data-page-y')
-    dragSource = undefined
+  // console.log('handleDropEffect', el)
+  dragSource && dragSource.removeAttribute('data-transfer')
+  if (el && el.classList.contains('letters__item')) {
+    el.classList.add('used')
+    el.draggable = false
+    setComplete($letters)
+    updateLetter(el.dataset.value, true)
+  } else if (el && el.classList.contains('words__cell')) {
+    el.innerText = ''
+    el.removeAttribute('data-value')
+    el.removeAttribute('draggable')
+    el.classList.remove('used')
+    removeDragging(el)
+    updateGrid('', el.dataset.row, el.dataset.col)
+  }
+  el.removeAttribute('data-page-x')
+  el.removeAttribute('data-page-y')
+  dragSource = undefined
 }
 
 const handleTouchMove = (e) => {
-    // console.log('handleTouchMove', e)
-    e.preventDefault()
-    const el = e.target
-    const touchLocation = e.targetTouches[0]
-    el.dataset.pageX = touchLocation.pageX - window.scrollX
-    el.dataset.pageY = touchLocation.pageY - window.scrollY
+  // console.log('handleTouchMove', e)
+  e.preventDefault()
+  const el = e.target
+  const touchLocation = e.targetTouches[0]
+  el.dataset.pageX = touchLocation.pageX - window.scrollX
+  el.dataset.pageY = touchLocation.pageY - window.scrollY
 
-    const touchElement = document.elementFromPoint(
-        el.dataset.pageX,
-        el.dataset.pageY,
-    )
-    const dragoverElement = document.querySelector('.dragover')
-    touchElement && touchElement.classList.add('dragover')
-    if (dragoverElement && touchElement !== dragoverElement) {
-        dragoverElement.classList.remove('dragover')
-    }
+  const touchElement = document.elementFromPoint(
+    el.dataset.pageX,
+    el.dataset.pageY,
+  )
+  const dragoverElement = document.querySelector('.dragover')
+  touchElement && touchElement.classList.add('dragover')
+  if (dragoverElement && touchElement !== dragoverElement) {
+    dragoverElement.classList.remove('dragover')
+  }
 }
 
 const handleTouchEnd = (e) => {
-    // console.log('handleTouchEnd', e)
-    const el = e.target
-    const dropElement = document.elementFromPoint(
-        el.dataset.pageX,
-        el.dataset.pageY,
-    )
-    dropTarget = getDropTarget(dropElement)
-    if (dropElement && isDropTarget(dropElement) && dropTarget !== dragSource) {
-        doDrop(dropElement)
-        handleDropEffect(el)
-    }
-    clearDragOver()
+  // console.log('handleTouchEnd', e)
+  const el = e.target
+  const dropElement = document.elementFromPoint(
+    el.dataset.pageX,
+    el.dataset.pageY,
+  )
+  dropTarget = getDropTarget(dropElement)
+  if (dropElement && isDropTarget(dropElement) && dropTarget !== dragSource) {
+    doDrop(dropElement)
+    handleDropEffect(el)
+  }
+  clearDragOver()
 }
 
 const handleDragOver = (e) => {
-    // console.log('handleDragOver', e)
-    e.preventDefault()
-    isDropTarget(e.target) && getDropTarget(e.target).classList.add('dragover')
+  // console.log('handleDragOver', e)
+  e.preventDefault()
+  isDropTarget(e.target) && getDropTarget(e.target).classList.add('dragover')
 }
 
 const handleDragLeave = (e) => {
-    // console.log('handleDragLeave', e)
-    let el = e.target
-    if (!el.classList) el = el.parentElement
-    el.classList.remove('dragover')
+  // console.log('handleDragLeave', e)
+  let el = e.target
+  if (!el.classList) el = el.parentElement
+  el.classList.remove('dragover')
 }
 
 const handleDrop = (e) => {
-    // console.log('handleDrop', e)
-    e.preventDefault()
-    doDrop(e.target)
-    clearDragOver()
+  // console.log('handleDrop', e)
+  e.preventDefault()
+  doDrop(e.target)
+  clearDragOver()
 }
 
 const doDrop = (el) => {
-    if (dragSource) {
-        const data = dragSource.dataset.transfer
-        dropTarget = getDropTarget(el)
-        dropTarget.classList.remove('dragover')
-        if (data !== undefined && dropTarget !== dragSource) {
-            if (el.classList.contains('words__cell')) {
-                // dropped onto word grid
-                if (el.dataset.value) handleReturn(el.dataset.value)
-                el.classList.add('used')
-                el.dataset.value = data
-                el.draggable = true
-                el.innerText = data
-                initDragging(el)
-                updateGrid(data, el.dataset.row, el.dataset.col)
-            } else {
-                handleReturn(data)
-            }
-        }
+  if (dragSource) {
+    const data = dragSource.dataset.transfer
+    dropTarget = getDropTarget(el)
+    dropTarget.classList.remove('dragover')
+    if (data !== undefined && dropTarget !== dragSource) {
+      if (el.classList.contains('words__cell')) {
+        // dropped onto word grid
+        if (el.dataset.value) handleReturn(el.dataset.value)
+        el.classList.add('used')
+        el.dataset.value = data
+        el.draggable = true
+        el.innerText = data
+        initDragging(el)
+        updateGrid(data, el.dataset.row, el.dataset.col)
+      } else {
+        handleReturn(data)
+      }
     }
+  }
 }
 
 // dropped back onto letter list
 const handleReturn = (data) => {
-    // console.log('handleReturn', data)
-    const letterItem = $letters.querySelector(
-        `.letters__item.used[data-value="${data}"]`,
-    )
-    if (letterItem) {
-        letterItem.classList.remove('used')
-        letterItem.draggable = true
-    }
-    setComplete($letters)
-    updateLetter(data, false)
+  // console.log('handleReturn', data)
+  const letterItem = $letters.querySelector(
+    `.letters__item.used[data-value="${data}"]`,
+  )
+  if (letterItem) {
+    letterItem.classList.remove('used')
+    letterItem.draggable = true
+  }
+  setComplete($letters)
+  updateLetter(data, false)
 }
 
 const clearDragOver = () => {
-    const dragOverElement = document.querySelector('.dragover')
-    dragOverElement && dragOverElement.classList.remove('dragover')
+  const dragOverElement = document.querySelector('.dragover')
+  dragOverElement && dragOverElement.classList.remove('dragover')
 }
 
 export const initDragging = (el) => {
-    el.addEventListener('touchstart', handleDragStart, {
-        passive: true,
-    })
-    el.addEventListener('dragstart', handleDragStart)
-    el.addEventListener('touchmove', handleTouchMove)
-    el.addEventListener('touchend', handleTouchEnd, {
-        passive: true,
-    })
-    el.addEventListener('dragend', handleDragEnd)
+  el.addEventListener('touchstart', handleDragStart, {
+    passive: true,
+  })
+  el.addEventListener('dragstart', handleDragStart)
+  el.addEventListener('touchmove', handleTouchMove)
+  el.addEventListener('touchend', handleTouchEnd, {
+    passive: true,
+  })
+  el.addEventListener('dragend', handleDragEnd)
 }
 
 const removeDragging = (el) => {
-    el.removeEventListener('touchstart', handleDragStart)
-    el.removeEventListener('dragstart', handleDragStart)
-    el.removeEventListener('touchmove', handleTouchMove)
-    el.removeEventListener('touchend', handleTouchEnd)
-    el.removeEventListener('dragend', handleDragEnd)
+  el.removeEventListener('touchstart', handleDragStart)
+  el.removeEventListener('dragstart', handleDragStart)
+  el.removeEventListener('touchmove', handleTouchMove)
+  el.removeEventListener('touchend', handleTouchEnd)
+  el.removeEventListener('dragend', handleDragEnd)
 }
 
 export const initDropping = (el) => {
-    el.addEventListener('dragover', handleDragOver)
-    el.addEventListener('dragleave', handleDragLeave)
-    el.addEventListener('drop', handleDrop)
+  el.addEventListener('dragover', handleDragOver)
+  el.addEventListener('dragleave', handleDragLeave)
+  el.addEventListener('drop', handleDrop)
 }

--- a/src/scripts/game.js
+++ b/src/scripts/game.js
@@ -1,106 +1,98 @@
-import {
-    buildLetters,
-} from './letters'
-import {
-    buildGrid,
-} from './grid'
-import {
-    swapIcons,
-    hideButtonText,
-    hideHeaderFooter,
-} from './toggle'
+import { buildLetters } from './letters'
+import { buildGrid } from './grid'
+import { swapIcons, hideButtonText, hideHeaderFooter } from './toggle'
 
 export const STORAGEID = 'game'
 
 export const dice = [
-    ['D', 'E', 'N', 'O', 'S', 'W'],
-    ['A', 'E', 'F', 'J', 'R', 'Z'],
-    ['E', 'G', 'K', 'L', 'U', 'Y'],
-    ['D', 'I', 'K', 'O', 'P', 'W'],
-    ['A', 'A', 'C', 'E', 'J', 'P'],
-    ['B', 'F', 'I', 'O', 'R', 'X'],
-    ['A', 'E', 'E', 'F', 'H', 'M'],
-    ['A', 'A', 'C', 'I', 'O', 'T'],
-    ['A', 'H', 'M', 'O', 'R', 'S'],
-    ['A', 'B', 'I', 'L', 'T', 'Y'],
-    ['A', 'D', 'N', 'T', 'W', 'Y'],
-    ['A', 'D', 'E', 'I', 'L', 'O'],
-    ['E', 'G', 'I', 'N', 'T', 'V'],
-    ['D', 'K', 'N', 'O', 'T', 'U'],
-    ['E', 'F', 'H', 'I', 'T', 'Y'],
-    ['A', 'D', 'G', 'H', 'I', 'T'],
-    ['A', 'D', 'E', 'H', 'N', 'T'],
-    ['A', 'B', 'E', 'K', 'L', 'U'],
-    ['A', 'E', 'M', 'P', 'S', 'Y'],
-    ['E', 'H', 'I', 'N', 'P', 'S'],
-    ['A', 'C', 'E', 'L', 'R', 'S'],
-    ['B', 'F', 'O', 'R', 'U', ' '],
-    ['H', 'I', 'L', 'O', 'S', 'X'],
-    ['F', 'L', 'O', 'R', 'Z', ' '],
-    ['A', 'C', 'D', 'E', 'N', 'P'],
-    ['U', 'U', 'U', 'U', 'U', 'U'],
-    ['A', 'C', 'G', 'R', 'S', 'T'],
-    ['G', 'I', 'L', 'M', 'R', 'W'],
-    ['A', 'B', 'L', 'M', 'O', 'Q'],
-    ['A', 'E', 'G', 'M', 'R', 'S'],
-    ['A', 'D', 'E', 'O', 'T', 'V'],
-    ['A', 'D', 'E', 'J', 'P', 'V'],
+  ['D', 'E', 'N', 'O', 'S', 'W'],
+  ['A', 'E', 'F', 'J', 'R', 'Z'],
+  ['E', 'G', 'K', 'L', 'U', 'Y'],
+  ['D', 'I', 'K', 'O', 'P', 'W'],
+  ['A', 'A', 'C', 'E', 'J', 'P'],
+  ['B', 'F', 'I', 'O', 'R', 'X'],
+  ['A', 'E', 'E', 'F', 'H', 'M'],
+  ['A', 'A', 'C', 'I', 'O', 'T'],
+  ['A', 'H', 'M', 'O', 'R', 'S'],
+  ['A', 'B', 'I', 'L', 'T', 'Y'],
+  ['A', 'D', 'N', 'T', 'W', 'Y'],
+  ['A', 'D', 'E', 'I', 'L', 'O'],
+  ['E', 'G', 'I', 'N', 'T', 'V'],
+  ['D', 'K', 'N', 'O', 'T', 'U'],
+  ['E', 'F', 'H', 'I', 'T', 'Y'],
+  ['A', 'D', 'G', 'H', 'I', 'T'],
+  ['A', 'D', 'E', 'H', 'N', 'T'],
+  ['A', 'B', 'E', 'K', 'L', 'U'],
+  ['A', 'E', 'M', 'P', 'S', 'Y'],
+  ['E', 'H', 'I', 'N', 'P', 'S'],
+  ['A', 'C', 'E', 'L', 'R', 'S'],
+  ['B', 'F', 'O', 'R', 'U', ' '],
+  ['H', 'I', 'L', 'O', 'S', 'X'],
+  ['F', 'L', 'O', 'R', 'Z', ' '],
+  ['A', 'C', 'D', 'E', 'N', 'P'],
+  ['U', 'U', 'U', 'U', 'U', 'U'],
+  ['A', 'C', 'G', 'R', 'S', 'T'],
+  ['G', 'I', 'L', 'M', 'R', 'W'],
+  ['A', 'B', 'L', 'M', 'O', 'Q'],
+  ['A', 'E', 'G', 'M', 'R', 'S'],
+  ['A', 'D', 'E', 'O', 'T', 'V'],
+  ['A', 'D', 'E', 'J', 'P', 'V'],
 ]
 
 export const defaultGame = {
-    letters: [],
-    grid: {
-        height: 10,
-        width: 10,
-        rows: [],
-    },
+  letters: [],
+  grid: {
+    height: 10,
+    width: 10,
+    rows: [],
+  },
 }
 
 // Get game object from storage
 export const getGame = () => {
-    const game = window.localStorage.getItem(STORAGEID)
-    if (game) return JSON.parse(game)
-    return defaultGame
+  const game = window.localStorage.getItem(STORAGEID)
+  if (game) return JSON.parse(game)
+  return defaultGame
 }
 
 // Set game object in storage
 export const setGame = (game) => {
-    window.localStorage.setItem(STORAGEID, JSON.stringify(game))
-    return game
+  window.localStorage.setItem(STORAGEID, JSON.stringify(game))
+  return game
 }
 
 export const setComplete = ($letters) => {
-    $letters.classList.remove('complete')
-    if (!document.querySelectorAll('.letters__item:not(.used)').length) {
-        $letters.classList.add('complete')
-        return true
-    }
-    return false
+  $letters.classList.remove('complete')
+  if (!document.querySelectorAll('.letters__item:not(.used)').length) {
+    $letters.classList.add('complete')
+    return true
+  }
+  return false
 }
 
 export const initialize = () => {
-    // handle localStorage
-    const compress = window.localStorage.getItem('compress')
-    const iconsOnly = window.localStorage.getItem('iconsOnly')
-    if (compress) {
-        hideHeaderFooter()
-        swapIcons(document.getElementById('toggleHeaderFooter'))
-    }
-    if (iconsOnly) {
-        hideButtonText()
-        swapIcons(document.getElementById('toggleButtonText'))
-    }
+  // handle localStorage
+  const compress = window.localStorage.getItem('compress')
+  const iconsOnly = window.localStorage.getItem('iconsOnly')
+  if (compress) {
+    hideHeaderFooter()
+    swapIcons(document.getElementById('toggleHeaderFooter'))
+  }
+  if (iconsOnly) {
+    hideButtonText()
+    swapIcons(document.getElementById('toggleButtonText'))
+  }
 
-    buildLetters()
-    buildGrid({})
+  buildLetters()
+  buildGrid({})
 }
 
 export const roll = () => {
-    setGame(defaultGame)
-    buildLetters(false)
-    buildGrid({
-        height: defaultGame.grid.height,
-        width: defaultGame.grid.width,
-        stored: false,
-    })
+  setGame(defaultGame)
+  buildLetters(false)
+  buildGrid({
+    height: defaultGame.grid.height,
+    width: defaultGame.grid.width,
+    stored: false,
+  })
 }

--- a/src/scripts/grid.js
+++ b/src/scripts/grid.js
@@ -1,175 +1,159 @@
-import {
-    getGame,
-    setGame,
-} from './game'
-import {
-    resetLetters,
-} from './letters'
-import {
-    initDragging,
-    initDropping,
-} from './dragDrop'
+import { getGame, setGame } from './game'
+import { resetLetters } from './letters'
+import { initDragging, initDropping } from './dragDrop'
 
 const $words = document.getElementById('words__grid').querySelector('tbody')
 
 // Get and set grid height from game object
 export const getHeight = () => {
-    const game = getGame()
-    const {
-        grid: {
-            height,
-        },
-    } = game
-    return height
+  const game = getGame()
+  const {
+    grid: { height },
+  } = game
+  return height
 }
 
 export const setHeight = (height) => {
-    const game = getGame()
-    setGame({
-        ...game,
-        grid: {
-            ...game.grid,
-            height,
-        },
-    })
+  const game = getGame()
+  setGame({
+    ...game,
+    grid: {
+      ...game.grid,
+      height,
+    },
+  })
 }
 
 // Get and set grid width from game object
 export const getWidth = () => {
-    const game = getGame()
-    const {
-        grid: {
-            width,
-        },
-    } = game
-    return width
+  const game = getGame()
+  const {
+    grid: { width },
+  } = game
+  return width
 }
 
 export const setWidth = (width) => {
-    const game = getGame()
-    setGame({
-        ...game,
-        grid: {
-            ...game.grid,
-            width,
-        },
-    })
+  const game = getGame()
+  setGame({
+    ...game,
+    grid: {
+      ...game.grid,
+      width,
+    },
+  })
 }
 
 /* Create and update grid */
 export const buildGrid = (props) => {
-    const {
-        height = getHeight(), width = getWidth(), stored = true,
-    } = props
-    const game = getGame()
-    $words.innerHTML = ''
-    for (let r = 0; r < height; r++) {
-        if (!game.grid.rows[r]) game.grid.rows[r] = Array(game.grid.width).fill('')
-        setGame(game)
-        $words.appendChild(createGridRow(width, r, stored))
-    }
+  const { height = getHeight(), width = getWidth(), stored = true } = props
+  const game = getGame()
+  $words.innerHTML = ''
+  for (let r = 0; r < height; r++) {
+    if (!game.grid.rows[r]) game.grid.rows[r] = Array(game.grid.width).fill('')
+    setGame(game)
+    $words.appendChild(createGridRow(width, r, stored))
+  }
 }
 
 export const resetGrid = () => {
-    const game = getGame()
-    game.grid.rows = Array(game.grid.height)
-        .fill()
-        .map(() => Array(game.grid.width).fill(''))
-    setGame(game)
-    resetLetters()
-    buildGrid({})
+  const game = getGame()
+  game.grid.rows = Array(game.grid.height)
+    .fill()
+    .map(() => Array(game.grid.width).fill(''))
+  setGame(game)
+  resetLetters()
+  buildGrid({})
 }
 
 export const updateGrid = (letter, row, column) => {
-    const game = getGame()
-    game.grid.rows[row][column] = letter
-    setGame(game)
+  const game = getGame()
+  game.grid.rows[row][column] = letter
+  setGame(game)
 }
 
 const indexGrid = () => {
-    [...$words.querySelectorAll('tr')].forEach((tr, r) => {
-        [...tr.querySelectorAll('td')].forEach((td, c) => {
-            td.dataset.row = r
-            td.dataset.col = c
-        })
+  ;[...$words.querySelectorAll('tr')].forEach((tr, r) => {
+    ;[...tr.querySelectorAll('td')].forEach((td, c) => {
+      td.dataset.row = r
+      td.dataset.col = c
     })
+  })
 }
 
 export const createGridCell = (r, c, stored = true) => {
-    const {
-        grid: {
-            rows,
-        },
-    } = getGame()
-    const cell = document.createElement('td')
-    cell.className = 'words__cell'
-    cell.dataset.row = r
-    cell.dataset.col = c
-    if (stored && rows[r][c]) {
-        cell.dataset.value = rows[r][c]
-        cell.innerText = rows[r][c]
-        cell.classList.add('used')
-        cell.draggable = true
-        initDragging(cell)
-    }
-    initDropping(cell)
-    return cell
+  const {
+    grid: { rows },
+  } = getGame()
+  const cell = document.createElement('td')
+  cell.className = 'words__cell'
+  cell.dataset.row = r
+  cell.dataset.col = c
+  if (stored && rows[r][c]) {
+    cell.dataset.value = rows[r][c]
+    cell.innerText = rows[r][c]
+    cell.classList.add('used')
+    cell.draggable = true
+    initDragging(cell)
+  }
+  initDropping(cell)
+  return cell
 }
 
 export const createGridRow = (width, r, stored = true) => {
-    const row = document.createElement('tr')
-    for (let c = 0; c < width; c++) {
-        row.appendChild(createGridCell(r, c, stored))
-    }
-    return row
+  const row = document.createElement('tr')
+  for (let c = 0; c < width; c++) {
+    row.appendChild(createGridCell(r, c, stored))
+  }
+  return row
 }
 
 const addRow = (direction = 'top') => {
-    const game = getGame()
-    if (direction === 'top') {
-        $words.insertBefore(
-            createGridRow(game.grid.width, 0, false),
-            $words.firstChild,
-            false,
-        )
-        game.grid.rows.unshift(Array(game.grid.width).fill(''))
-    } else {
-        $words.appendChild(createGridRow(game.grid.width, game.grid.height, false))
-        game.grid.rows.push(Array(game.grid.width).fill(''))
-    }
-    game.grid.height++
-    setGame(game)
-    indexGrid()
+  const game = getGame()
+  if (direction === 'top') {
+    $words.insertBefore(
+      createGridRow(game.grid.width, 0, false),
+      $words.firstChild,
+      false,
+    )
+    game.grid.rows.unshift(Array(game.grid.width).fill(''))
+  } else {
+    $words.appendChild(createGridRow(game.grid.width, game.grid.height, false))
+    game.grid.rows.push(Array(game.grid.width).fill(''))
+  }
+  game.grid.height++
+  setGame(game)
+  indexGrid()
 }
 
 const addColumn = (direction = 'left') => {
-    const game = getGame();
-    [...$words.querySelectorAll('tr')].forEach((tr, r) => {
-        if (direction === 'left') {
-            tr.insertBefore(createGridCell(r, 0, false), tr.firstChild)
-            game.grid.rows[r].unshift('')
-        } else {
-            tr.appendChild(createGridCell(r, game.grid.width, false))
-            game.grid.rows[r].push('')
-        }
-    })
-    game.grid.width++
-    setGame(game)
-    indexGrid()
+  const game = getGame()
+  ;[...$words.querySelectorAll('tr')].forEach((tr, r) => {
+    if (direction === 'left') {
+      tr.insertBefore(createGridCell(r, 0, false), tr.firstChild)
+      game.grid.rows[r].unshift('')
+    } else {
+      tr.appendChild(createGridCell(r, game.grid.width, false))
+      game.grid.rows[r].push('')
+    }
+  })
+  game.grid.width++
+  setGame(game)
+  indexGrid()
 }
 
 export const addRowTop = () => {
-    addRow('top')
+  addRow('top')
 }
 
 export const addRowBottom = () => {
-    addRow('bottom')
+  addRow('bottom')
 }
 
 export const addColumnLeft = () => {
-    addColumn('left')
+  addColumn('left')
 }
 
 export const addColumnRight = () => {
-    addColumn('right')
+  addColumn('right')
 }

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,26 +1,16 @@
 import 'tippy.js/dist/tippy.css'
-import {
-    cleanup,
-} from './cleanup'
+import { cleanup } from './cleanup'
 import registerServiceWorker from './serviceWorker'
+import { initialize, roll } from './game'
 import {
-    initialize,
-    roll,
-} from './game'
-import {
-    addRowTop,
-    addRowBottom,
-    addColumnLeft,
-    addColumnRight,
-    resetGrid,
+  addRowTop,
+  addRowBottom,
+  addColumnLeft,
+  addColumnRight,
+  resetGrid,
 } from './grid'
-import {
-    toggleButtonText,
-    toggleHeaderFooter,
-} from './toggle'
-import {
-    handleKeyboard,
-} from './keyboard'
+import { toggleButtonText, toggleHeaderFooter } from './toggle'
+import { handleKeyboard } from './keyboard'
 import tippy from 'tippy.js'
 
 cleanup()
@@ -32,23 +22,23 @@ document.getElementById('reset').addEventListener('click', resetGrid)
 document.getElementById('addRowTop').addEventListener('click', addRowTop)
 document.getElementById('addRowBottom').addEventListener('click', addRowBottom)
 document
-    .getElementById('addColumnLeft')
-    .addEventListener('click', addColumnLeft)
+  .getElementById('addColumnLeft')
+  .addEventListener('click', addColumnLeft)
 document
-    .getElementById('addColumnRight')
-    .addEventListener('click', addColumnRight)
+  .getElementById('addColumnRight')
+  .addEventListener('click', addColumnRight)
 document.addEventListener('keyup', handleKeyboard, false)
 document
-    .getElementById('toggleHeaderFooter')
-    .addEventListener('click', toggleHeaderFooter)
+  .getElementById('toggleHeaderFooter')
+  .addEventListener('click', toggleHeaderFooter)
 document
-    .getElementById('toggleButtonText')
-    .addEventListener('click', toggleButtonText)
+  .getElementById('toggleButtonText')
+  .addEventListener('click', toggleButtonText)
 
 // initialize game board
 initialize()
 
 // initialize tooltips
 tippy('[data-tippy-content]', {
-    placement: 'right',
+  placement: 'right',
 })

--- a/src/scripts/keyboard.js
+++ b/src/scripts/keyboard.js
@@ -1,48 +1,43 @@
+import { roll } from './game'
 import {
-    roll,
-} from './game'
-import {
-    addRowTop,
-    addRowBottom,
-    addColumnLeft,
-    addColumnRight,
-    resetGrid,
+  addRowTop,
+  addRowBottom,
+  addColumnLeft,
+  addColumnRight,
+  resetGrid,
 } from './grid'
-import {
-    toggleButtonText,
-    toggleHeaderFooter,
-} from './toggle'
+import { toggleButtonText, toggleHeaderFooter } from './toggle'
 
 export const handleKeyboard = (e) => {
-    if (e.ctrlKey) {
-        e.preventDefault()
+  if (e.ctrlKey) {
+    e.preventDefault()
 
-        switch (e.keyCode) {
-            case 13: // Enter
-                roll()
-                break
-            case 36: // Home
-                resetGrid()
-                break
-            case 37: // Arrow left
-                addColumnLeft()
-                break
-            case 38: // Arrow up
-                addRowTop()
-                break
-            case 39: // Arrow right
-                addColumnRight()
-                break
-            case 40: // Arrow down
-                addRowBottom()
-                break
-            case 46: // Delete
-                toggleHeaderFooter()
-                break
-            case 32: // Space
-                toggleButtonText()
-                break
-            default:
-        }
+    switch (e.keyCode) {
+      case 13: // Enter
+        roll()
+        break
+      case 36: // Home
+        resetGrid()
+        break
+      case 37: // Arrow left
+        addColumnLeft()
+        break
+      case 38: // Arrow up
+        addRowTop()
+        break
+      case 39: // Arrow right
+        addColumnRight()
+        break
+      case 40: // Arrow down
+        addRowBottom()
+        break
+      case 46: // Delete
+        toggleHeaderFooter()
+        break
+      case 32: // Space
+        toggleButtonText()
+        break
+      default:
     }
+  }
 }

--- a/src/scripts/letters.js
+++ b/src/scripts/letters.js
@@ -1,80 +1,72 @@
-import {
-    dice,
-    getGame,
-    setGame,
-    setComplete,
-} from './game'
-import {
-    initDragging,
-    initDropping,
-} from './dragDrop'
+import { dice, getGame, setGame, setComplete } from './game'
+import { initDragging, initDropping } from './dragDrop'
 
 export const $letters = document.getElementById('letters__list')
 
 const getLetters = (stored = true) => {
-    const game = getGame()
-    if (stored && game.letters.length) return game.letters
+  const game = getGame()
+  if (stored && game.letters.length) return game.letters
 
-    const letters = []
-    dice.forEach((d) => {
-        letters.push({
-            letter: d[Math.floor(Math.random() * d.length)],
-            used: false,
-        })
+  const letters = []
+  dice.forEach((d) => {
+    letters.push({
+      letter: d[Math.floor(Math.random() * d.length)],
+      used: false,
     })
-    letters.sort((a, b) =>
-        a.letter === b.letter ? 0 : a.letter > b.letter ? 1 : -1,
-    )
-    setGame({
-        ...game,
-        letters,
-    })
-    return letters
+  })
+  letters.sort((a, b) =>
+    a.letter === b.letter ? 0 : a.letter > b.letter ? 1 : -1,
+  )
+  setGame({
+    ...game,
+    letters,
+  })
+  return letters
 }
 
 export const buildLetters = (stored = true) => {
-    $letters.innerHTML = ''
-    getLetters(stored).forEach((l) => {
-        const letter = document.createElement('li')
-        letter.className = 'letters__item'
-        letter.dataset.value = l.letter
-        letter.innerText = l.letter
-        letter.draggable = !l.used
-        if (l.used) letter.classList.add('used')
-        initDragging(letter)
-        $letters.appendChild(letter)
-    })
-    initDropping(document.getElementById('letters'))
-    setComplete($letters)
+  $letters.innerHTML = ''
+  getLetters(stored).forEach((l) => {
+    const letter = document.createElement('li')
+    letter.className = 'letters__item'
+    letter.dataset.value = l.letter
+    letter.innerText = l.letter
+    letter.draggable = !l.used
+    if (l.used) letter.classList.add('used')
+    initDragging(letter)
+    $letters.appendChild(letter)
+  })
+  initDropping(document.getElementById('letters'))
+  setComplete($letters)
 }
 
 export const resetLetters = () => {
-    const game = getGame()
-    const letters = game.letters;
-    [...document.querySelectorAll('.letters__item')].forEach((el) => {
-        el.classList.remove('used')
-        el.draggable = true
-    })
-    letters.forEach(l => (l.used = false))
-    setComplete($letters)
-    setGame({
-        ...game,
-        letters,
-    })
+  const game = getGame()
+  const letters = game.letters
+  ;[...document.querySelectorAll('.letters__item')].forEach((el) => {
+    el.classList.remove('used')
+    el.draggable = true
+  })
+  letters.forEach((l) => (l.used = false))
+  setComplete($letters)
+  setGame({
+    ...game,
+    letters,
+  })
 }
 
 export const updateLetter = (letter, used) => {
-    const game = getGame()
-    const letters = game.letters
-    const l = letters.length
-    for (let i = 0; i < l; i++) {
-        if (letters[i].letter === letter && letters[i].used === !used) {
-            letters[i].used = used
-            break
-        }
+  const game = getGame()
+  const letters = game.letters
+  const l = letters.length
+  for (let i = 0; i < l; i++) {
+    if (letters[i].letter === letter && letters[i].used === !used) {
+      letters[i].used = used
+      break
     }
-    setGame({
-        ...game,
-        letters,
-    })
+  }
+  setGame({
+    ...game,
+    letters,
+  })
 }

--- a/src/scripts/serviceWorker.js
+++ b/src/scripts/serviceWorker.js
@@ -1,37 +1,35 @@
-import {
-    STORAGEID,
-} from './game'
+import { STORAGEID } from './game'
 
 const registerServiceWorker = () => {
-    // https://deanhume.com/displaying-a-new-version-available-progressive-web-app/
-    let newWorker
-    document.getElementById('reload').addEventListener('click', (e) => {
-        e.preventDefault()
-        newWorker.postMessage({
-            action: 'skipWaiting',
-        })
-        window.sessionStorage.removeItem(STORAGEID)
-        window.localStorage.removeItem(STORAGEID)
-        window.location.reload()
+  // https://deanhume.com/displaying-a-new-version-available-progressive-web-app/
+  let newWorker
+  document.getElementById('reload').addEventListener('click', (e) => {
+    e.preventDefault()
+    newWorker.postMessage({
+      action: 'skipWaiting',
     })
-    if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('sw.js').then((reg) => {
-            reg.addEventListener('updatefound', () => {
-                newWorker = reg.installing
-                newWorker.addEventListener('statechange', () => {
-                    switch (newWorker.state) {
-                        case 'installed':
-                            if (navigator.serviceWorker.controller) {
-                                document
-                                    .getElementById('notification')
-                                    .removeAttribute('hidden')
-                            }
-                            break
-                    }
-                })
-            })
+    window.sessionStorage.removeItem(STORAGEID)
+    window.localStorage.removeItem(STORAGEID)
+    window.location.reload()
+  })
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').then((reg) => {
+      reg.addEventListener('updatefound', () => {
+        newWorker = reg.installing
+        newWorker.addEventListener('statechange', () => {
+          switch (newWorker.state) {
+            case 'installed':
+              if (navigator.serviceWorker.controller) {
+                document
+                  .getElementById('notification')
+                  .removeAttribute('hidden')
+              }
+              break
+          }
         })
-    }
+      })
+    })
+  }
 }
 
 export default registerServiceWorker

--- a/src/scripts/toggle.js
+++ b/src/scripts/toggle.js
@@ -4,52 +4,52 @@ const footer = document.getElementById('footer')
 const buttonText = [...document.querySelectorAll('span.js-canHide')]
 
 const showHeaderFooter = () => {
-    window.localStorage.removeItem('compress')
-    header.classList.remove('visually-hidden')
-    footer.classList.remove('visually-hidden')
+  window.localStorage.removeItem('compress')
+  header.classList.remove('visually-hidden')
+  footer.classList.remove('visually-hidden')
 }
 
 export const hideHeaderFooter = () => {
-    window.localStorage.setItem('compress', 'true')
-    header.classList.add('visually-hidden')
-    footer.classList.add('visually-hidden')
+  window.localStorage.setItem('compress', 'true')
+  header.classList.add('visually-hidden')
+  footer.classList.add('visually-hidden')
 }
 
 export const toggleHeaderFooter = () => {
-    if (header.classList.contains('visually-hidden')) {
-        showHeaderFooter()
-    } else {
-        hideHeaderFooter()
-    }
-    swapIcons(document.getElementById('toggleHeaderFooter'))
+  if (header.classList.contains('visually-hidden')) {
+    showHeaderFooter()
+  } else {
+    hideHeaderFooter()
+  }
+  swapIcons(document.getElementById('toggleHeaderFooter'))
 }
 
 const showButtonText = () => {
-    window.localStorage.removeItem('iconsOnly')
-    buttonText.forEach(b => b.classList.remove('visually-hidden'))
+  window.localStorage.removeItem('iconsOnly')
+  buttonText.forEach((b) => b.classList.remove('visually-hidden'))
 }
 
 export const hideButtonText = () => {
-    window.localStorage.setItem('iconsOnly', 'true')
-    buttonText.forEach(b => b.classList.add('visually-hidden'))
+  window.localStorage.setItem('iconsOnly', 'true')
+  buttonText.forEach((b) => b.classList.add('visually-hidden'))
 }
 
 export const toggleButtonText = () => {
-    if (buttonText[0].classList.contains('visually-hidden')) {
-        showButtonText()
-    } else {
-        hideButtonText()
-    }
-    swapIcons(document.getElementById('toggleButtonText'))
+  if (buttonText[0].classList.contains('visually-hidden')) {
+    showButtonText()
+  } else {
+    hideButtonText()
+  }
+  swapIcons(document.getElementById('toggleButtonText'))
 }
 
 // Swap icons
 export const swapIcons = (el) => {
-    [...el.querySelectorAll('svg')].forEach((s) => {
-        if (s.hasAttribute('hidden')) {
-            s.removeAttribute('hidden')
-        } else {
-            s.setAttribute('hidden', true)
-        }
-    })
+  ;[...el.querySelectorAll('svg')].forEach((s) => {
+    if (s.hasAttribute('hidden')) {
+      s.removeAttribute('hidden')
+    } else {
+      s.setAttribute('hidden', true)
+    }
+  })
 }

--- a/src/site.webmanifest
+++ b/src/site.webmanifest
@@ -1,26 +1,26 @@
 {
-    "name": "Words: a word tile game",
-    "short_name": "Words",
-    "icons": [
-        {
-            "src": "/android-chrome-192x192.png?v=eEvolvQr5k",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-256x256.png?v=eEvolvQr5k",
-            "sizes": "256x256",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-512x512.png?v=eEvolvQr5k",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "start_url": "/words/?source=pwa",
-    "theme_color": "#005b99",
-    "background_color": "#ffffff",
-    "display": "standalone",
-    "scope": "/words"
+  "name": "Words: a word tile game",
+  "short_name": "Words",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png?v=eEvolvQr5k",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-256x256.png?v=eEvolvQr5k",
+      "sizes": "256x256",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png?v=eEvolvQr5k",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/words/?source=pwa",
+  "theme_color": "#005b99",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "scope": "/words"
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -14,145 +14,145 @@ $green: #036803;
 $spacing: 1rem;
 
 main.main {
-    margin-top: math.div($spacing, 2);
+  margin-top: math.div($spacing, 2);
 
-    @media (min-width: 992px) {
-        margin-top: $spacing;
-    }
+  @media (min-width: 992px) {
+    margin-top: $spacing;
+  }
 }
 
 footer {
-    border-top: 1px solid $grey-300;
-    color: $grey-700;
-    margin-top: $spacing * 2;
-    padding: $spacing;
+  border-top: 1px solid $grey-300;
+  color: $grey-700;
+  margin-top: $spacing * 2;
+  padding: $spacing;
 }
 
 .letters {
-    margin-left: math.div($spacing, 2);
-    margin-top: 0;
-    max-width: 18rem;
+  margin-left: math.div($spacing, 2);
+  margin-top: 0;
+  max-width: 18rem;
 
-    @media (min-width: 992px) {
-        margin-left: $spacing;
-        margin-top: math.div($spacing, 2);
+  @media (min-width: 992px) {
+    margin-left: $spacing;
+    margin-top: math.div($spacing, 2);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: math.div($spacing, 2);
+    padding-left: math.div($spacing, 2);
+    padding-top: math.div($spacing, 2);
+
+    &.complete {
+      background-color: color.scale($green, $lightness: 72%);
     }
-
-    &__list {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        margin-bottom: 0;
-        margin-left: 0;
-        margin-right: math.div($spacing, 2);
-        padding-left: math.div($spacing, 2);
-        padding-top: math.div($spacing, 2);
-
-        &.complete {
-            background-color: color.scale($green, $lightness: 72%);
-        }
-    }
+  }
 }
 
 .words {
-    margin-top: math.div($spacing, 2);
-    overflow: auto;
+  margin-top: math.div($spacing, 2);
+  overflow: auto;
 
-    @media (min-width: 992px) {
-        margin-top: $spacing;
-    }
+  @media (min-width: 992px) {
+    margin-top: $spacing;
+  }
 
-    &__grid {
-        border-collapse: collapse;
-        border: 2px solid $grey-700;
-    }
+  &__grid {
+    border-collapse: collapse;
+    border: 2px solid $grey-700;
+  }
 }
 
 .controls {
-    margin-top: math.div($spacing, 2);
+  margin-top: math.div($spacing, 2);
 
-    @media (min-width: 992px) {
-        margin-top: $spacing;
+  @media (min-width: 992px) {
+    margin-top: $spacing;
+  }
+
+  & > button {
+    display: block;
+    text-align: left;
+    width: 100%;
+
+    &:first-child {
+      margin-top: 0;
     }
-
-    &>button {
-        display: block;
-        text-align: left;
-        width: 100%;
-
-        &:first-child {
-            margin-top: 0;
-        }
-    }
+  }
 }
 
 .letters__item,
 .words__cell {
-    background-color: $white;
-    padding: math.div($spacing, 2);
-    text-align: center;
-    min-width: 2.5rem;
+  background-color: $white;
+  padding: math.div($spacing, 2);
+  text-align: center;
+  min-width: 2.5rem;
 
-    &:empty::after {
-        content: '\00a0';
-    }
+  &:empty::after {
+    content: '\00a0';
+  }
 
-    @media (min-width: 992px) {
-        padding: $spacing;
-        min-width: 3.5rem;
-    }
+  @media (min-width: 992px) {
+    padding: $spacing;
+    min-width: 3.5rem;
+  }
 }
 
 .letters__item {
-    border: 2px solid $grey-500;
-    list-style: none;
-    margin-bottom: math.div($spacing, 2);
-    margin-right: math.div($spacing, 2);
+  border: 2px solid $grey-500;
+  list-style: none;
+  margin-bottom: math.div($spacing, 2);
+  margin-right: math.div($spacing, 2);
 
-    &.used {
-        background-color: $grey-100;
-        border-color: $grey-300;
-        color: $grey-700;
-    }
+  &.used {
+    background-color: $grey-100;
+    border-color: $grey-300;
+    color: $grey-700;
+  }
 }
 
 .words__cell {
-    border: 1px dashed $grey-500;
+  border: 1px dashed $grey-500;
 
-    &:empty::after {
-        content: '\00a0';
+  &:empty::after {
+    content: '\00a0';
+  }
+
+  &.used {
+    border: 2px solid $primary;
+    padding: calc(#{math.div($spacing, 2)} - 1px);
+
+    @media (min-width: 992px) {
+      padding: calc(#{$spacing} - 1px);
     }
-
-    &.used {
-        border: 2px solid $primary;
-        padding: calc(#{math.div($spacing, 2)} - 1px);
-
-        @media (min-width: 992px) {
-            padding: calc(#{$spacing} - 1px);
-        }
-    }
+  }
 }
 
 .dragover {
-    background-color: color.scale($primary, $lightness: 64%);
+  background-color: color.scale($primary, $lightness: 64%);
 }
 
 .icon {
-    display: inline-block;
-    font-size: inherit;
-    height: 1em;
-    text-align: center;
-    vertical-align: -0.125em;
-    width: 1.25em;
+  display: inline-block;
+  font-size: inherit;
+  height: 1em;
+  text-align: center;
+  vertical-align: -0.125em;
+  width: 1.25em;
 }
 
 [draggable='true'] {
-    cursor: move;
+  cursor: move;
 }
 
 [draggable='false'] {
-    cursor: not-allowed;
+  cursor: not-allowed;
 }
 
 [hidden] {
-    display: none !important;
+  display: none !important;
 }

--- a/src/sw.js
+++ b/src/sw.js
@@ -19,74 +19,75 @@ const RUNTIME = 'runtime'
 
 // A list of local resources we always want to be cached.
 const PRECACHE_URLS = [
-    './',
-    './?source=pwa',
-    'index.html',
-    './css/index.css',
-    './js/index.js',
+  './',
+  './?source=pwa',
+  'index.html',
+  './css/index.css',
+  './js/index.js',
 ]
 
 // The install handler takes care of pre-caching the resources we always need.
 self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches
-            .open(PRECACHE)
-            .then(cache => cache.addAll(PRECACHE_URLS))
-            .then(self.skipWaiting()),
-    )
+  event.waitUntil(
+    caches
+      .open(PRECACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(self.skipWaiting()),
+  )
 })
 
 // The activate handler takes care of cleaning up old caches.
 self.addEventListener('activate', (event) => {
-    const currentCaches = [PRECACHE, RUNTIME]
-    event.waitUntil(
-        caches
-            .keys()
-            .then((cacheNames) => {
-                return cacheNames.filter(
-                    cacheName => !currentCaches.includes(cacheName),
-                )
-            })
-            .then((cachesToDelete) => {
-                return Promise.all(
-                    cachesToDelete.map((cacheToDelete) => {
-                        return caches.delete(cacheToDelete)
-                    }),
-                )
-            })
-            .then(() => self.clients.claim()),
-    )
+  const currentCaches = [PRECACHE, RUNTIME]
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) => {
+        return cacheNames.filter(
+          (cacheName) => !currentCaches.includes(cacheName),
+        )
+      })
+      .then((cachesToDelete) => {
+        return Promise.all(
+          cachesToDelete.map((cacheToDelete) => {
+            return caches.delete(cacheToDelete)
+          }),
+        )
+      })
+      .then(() => self.clients.claim()),
+  )
 })
 
 self.addEventListener('message', (event) => {
-    if (event.data.action === 'skipWaiting') {
-        self.skipWaiting()
-    }
+  if (event.data.action === 'skipWaiting') {
+    self.skipWaiting()
+  }
 })
 
 // The fetch handler serves responses for same-origin resources from a cache.
 // If no response is found, it populates the runtime cache with the response
 // from the network before returning it to the page.
 self.addEventListener('fetch', (event) => {
-    // Skip cross-origin requests, like those for Google Analytics, and POSTs.
-    if (event.request.url.startsWith(self.location.origin) && event.request.method !== 'POST') {
-        event.respondWith(
-            caches.match(event.request).then((cachedResponse) => {
-                if (cachedResponse) {
-                    return cachedResponse
-                }
+  // Skip cross-origin requests, like those for Google Analytics, and POSTs.
+  if (
+    event.request.url.startsWith(self.location.origin) &&
+    event.request.method !== 'POST'
+  ) {
+    event.respondWith(
+      caches.match(event.request).then((cachedResponse) => {
+        if (cachedResponse) {
+          return cachedResponse
+        }
 
-                return caches.open(RUNTIME).then((cache) => {
-                    return fetch(event.request).then((response) => {
-                        // Put a copy of the response in the runtime cache.
-                        return cache
-                            .put(event.request, response.clone())
-                            .then(() => {
-                                return response
-                            })
-                    })
-                })
-            }),
-        )
-    }
+        return caches.open(RUNTIME).then((cache) => {
+          return fetch(event.request).then((response) => {
+            // Put a copy of the response in the runtime cache.
+            return cache.put(event.request, response.clone()).then(() => {
+              return response
+            })
+          })
+        })
+      }),
+    )
+  }
 })

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -1,27 +1,27 @@
 import { cleanup } from '../src/scripts/cleanup'
 
 beforeEach(() => {
-    localStorage.clear()
+  localStorage.clear()
 })
 
 describe('cleanup', () => {
-    it('removes legacy compress key', () => {
-        localStorage.setItem('craigmcn-words-compress', 'true')
-        cleanup()
-        expect(localStorage.getItem('craigmcn-words-compress')).toBeNull()
-    })
+  it('removes legacy compress key', () => {
+    localStorage.setItem('craigmcn-words-compress', 'true')
+    cleanup()
+    expect(localStorage.getItem('craigmcn-words-compress')).toBeNull()
+  })
 
-    it('removes legacy icons-only key', () => {
-        localStorage.setItem('craigmcn-words-icons-only', 'true')
-        cleanup()
-        expect(localStorage.getItem('craigmcn-words-icons-only')).toBeNull()
-    })
+  it('removes legacy icons-only key', () => {
+    localStorage.setItem('craigmcn-words-icons-only', 'true')
+    cleanup()
+    expect(localStorage.getItem('craigmcn-words-icons-only')).toBeNull()
+  })
 
-    it('does not remove unrelated localStorage keys', () => {
-        localStorage.setItem('compress', 'true')
-        localStorage.setItem('game', '{}')
-        cleanup()
-        expect(localStorage.getItem('compress')).toBe('true')
-        expect(localStorage.getItem('game')).toBe('{}')
-    })
+  it('does not remove unrelated localStorage keys', () => {
+    localStorage.setItem('compress', 'true')
+    localStorage.setItem('game', '{}')
+    cleanup()
+    expect(localStorage.getItem('compress')).toBe('true')
+    expect(localStorage.getItem('game')).toBe('{}')
+  })
 })

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,93 +1,103 @@
-import { dice, defaultGame, STORAGEID, getGame, setGame, setComplete } from '../src/scripts/game'
+import {
+  dice,
+  defaultGame,
+  STORAGEID,
+  getGame,
+  setGame,
+  setComplete,
+} from '../src/scripts/game'
 
 beforeEach(() => {
-    localStorage.clear()
+  localStorage.clear()
 })
 
 describe('dice', () => {
-    it('has 32 entries', () => {
-        expect(dice).toHaveLength(32)
-    })
+  it('has 32 entries', () => {
+    expect(dice).toHaveLength(32)
+  })
 
-    it('each die has 6 faces', () => {
-        dice.forEach(d => expect(d).toHaveLength(6))
-    })
+  it('each die has 6 faces', () => {
+    dice.forEach((d) => expect(d).toHaveLength(6))
+  })
 
-    it('all faces are single characters', () => {
-        dice.forEach(d => d.forEach(face => expect(face).toHaveLength(1)))
-    })
+  it('all faces are single characters', () => {
+    dice.forEach((d) => d.forEach((face) => expect(face).toHaveLength(1)))
+  })
 })
 
 describe('defaultGame', () => {
-    it('has an empty letters array', () => {
-        expect(defaultGame.letters).toEqual([])
-    })
+  it('has an empty letters array', () => {
+    expect(defaultGame.letters).toEqual([])
+  })
 
-    it('has a 10x10 grid', () => {
-        expect(defaultGame.grid.height).toBe(10)
-        expect(defaultGame.grid.width).toBe(10)
-        expect(defaultGame.grid.rows).toEqual([])
-    })
+  it('has a 10x10 grid', () => {
+    expect(defaultGame.grid.height).toBe(10)
+    expect(defaultGame.grid.width).toBe(10)
+    expect(defaultGame.grid.rows).toEqual([])
+  })
 })
 
 describe('getGame', () => {
-    it('returns defaultGame when localStorage is empty', () => {
-        expect(getGame()).toEqual(defaultGame)
-    })
+  it('returns defaultGame when localStorage is empty', () => {
+    expect(getGame()).toEqual(defaultGame)
+  })
 
-    it('returns parsed game from localStorage', () => {
-        const state = { letters: [{ letter: 'A', used: false }], grid: { height: 5, width: 5, rows: [] } }
-        localStorage.setItem(STORAGEID, JSON.stringify(state))
-        expect(getGame()).toEqual(state)
-    })
+  it('returns parsed game from localStorage', () => {
+    const state = {
+      letters: [{ letter: 'A', used: false }],
+      grid: { height: 5, width: 5, rows: [] },
+    }
+    localStorage.setItem(STORAGEID, JSON.stringify(state))
+    expect(getGame()).toEqual(state)
+  })
 })
 
 describe('setGame', () => {
-    it('persists game state to localStorage', () => {
-        const state = { letters: [], grid: { height: 3, width: 3, rows: [] } }
-        setGame(state)
-        expect(JSON.parse(localStorage.getItem(STORAGEID))).toEqual(state)
-    })
+  it('persists game state to localStorage', () => {
+    const state = { letters: [], grid: { height: 3, width: 3, rows: [] } }
+    setGame(state)
+    expect(JSON.parse(localStorage.getItem(STORAGEID))).toEqual(state)
+  })
 
-    it('returns the game object', () => {
-        const state = { letters: [], grid: defaultGame.grid }
-        expect(setGame(state)).toBe(state)
-    })
+  it('returns the game object', () => {
+    const state = { letters: [], grid: defaultGame.grid }
+    expect(setGame(state)).toBe(state)
+  })
 })
 
 describe('setComplete', () => {
-    let $letters
+  let $letters
 
-    beforeEach(() => {
-        $letters = document.getElementById('letters__list')
-        $letters.innerHTML = ''
-    })
+  beforeEach(() => {
+    $letters = document.getElementById('letters__list')
+    $letters.innerHTML = ''
+  })
 
-    it('adds complete class when all letter items are used', () => {
-        const li = document.createElement('li')
-        li.className = 'letters__item used'
-        $letters.appendChild(li)
-        setComplete($letters)
-        expect($letters.classList.contains('complete')).toBe(true)
-    })
+  it('adds complete class when all letter items are used', () => {
+    const li = document.createElement('li')
+    li.className = 'letters__item used'
+    $letters.appendChild(li)
+    setComplete($letters)
+    expect($letters.classList.contains('complete')).toBe(true)
+  })
 
-    it('removes complete class when any letter item is unused', () => {
-        $letters.classList.add('complete')
-        const li = document.createElement('li')
-        li.className = 'letters__item'
-        $letters.appendChild(li)
-        setComplete($letters)
-        expect($letters.classList.contains('complete')).toBe(false)
-    })
+  it('removes complete class when any letter item is unused', () => {
+    $letters.classList.add('complete')
+    const li = document.createElement('li')
+    li.className = 'letters__item'
+    $letters.appendChild(li)
+    setComplete($letters)
+    expect($letters.classList.contains('complete')).toBe(false)
+  })
 
-    it('returns true when complete', () => {
-        expect(setComplete($letters)).toBe(true)
-    })
+  it('returns true when complete', () => {
+    expect(setComplete($letters)).toBe(true)
+  })
 
-    it('returns false when not complete', () => {
-        const li = document.createElement('li')
-        li.className = 'letters__item'
-        $letters.appendChild(li)
-        expect(setComplete($letters)).toBe(false)
-    })
+  it('returns false when not complete', () => {
+    const li = document.createElement('li')
+    li.className = 'letters__item'
+    $letters.appendChild(li)
+    expect(setComplete($letters)).toBe(false)
+  })
 })

--- a/test/grid.test.js
+++ b/test/grid.test.js
@@ -1,127 +1,139 @@
 import { getGame, setGame } from '../src/scripts/game'
-import { getHeight, getWidth, setHeight, setWidth, updateGrid, createGridCell, createGridRow, addRowTop, addRowBottom, addColumnLeft, addColumnRight } from '../src/scripts/grid'
+import {
+  getHeight,
+  getWidth,
+  setHeight,
+  setWidth,
+  updateGrid,
+  createGridCell,
+  createGridRow,
+  addRowTop,
+  addRowBottom,
+  addColumnLeft,
+  addColumnRight,
+} from '../src/scripts/grid'
 
 const makeGame = (height = 3, width = 3) => ({
-    letters: [],
-    grid: {
-        height,
-        width,
-        rows: Array.from({ length: height }, () => Array(width).fill('')),
-    },
+  letters: [],
+  grid: {
+    height,
+    width,
+    rows: Array.from({ length: height }, () => Array(width).fill('')),
+  },
 })
 
 beforeEach(() => {
-    localStorage.clear()
-    setGame(makeGame())
-    document.querySelector('#words__grid tbody').innerHTML = ''
+  localStorage.clear()
+  setGame(makeGame())
+  document.querySelector('#words__grid tbody').innerHTML = ''
 })
 
 describe('getHeight / getWidth', () => {
-    it('reads height from game state', () => {
-        expect(getHeight()).toBe(3)
-    })
+  it('reads height from game state', () => {
+    expect(getHeight()).toBe(3)
+  })
 
-    it('reads width from game state', () => {
-        expect(getWidth()).toBe(3)
-    })
+  it('reads width from game state', () => {
+    expect(getWidth()).toBe(3)
+  })
 })
 
 describe('setHeight / setWidth', () => {
-    it('persists height to game state', () => {
-        setHeight(7)
-        expect(getGame().grid.height).toBe(7)
-    })
+  it('persists height to game state', () => {
+    setHeight(7)
+    expect(getGame().grid.height).toBe(7)
+  })
 
-    it('persists width to game state', () => {
-        setWidth(5)
-        expect(getGame().grid.width).toBe(5)
-    })
+  it('persists width to game state', () => {
+    setWidth(5)
+    expect(getGame().grid.width).toBe(5)
+  })
 })
 
 describe('updateGrid', () => {
-    it('saves a letter at the correct position', () => {
-        updateGrid('A', 1, 2)
-        expect(getGame().grid.rows[1][2]).toBe('A')
-    })
+  it('saves a letter at the correct position', () => {
+    updateGrid('A', 1, 2)
+    expect(getGame().grid.rows[1][2]).toBe('A')
+  })
 
-    it('does not affect other cells', () => {
-        updateGrid('Z', 0, 0)
-        expect(getGame().grid.rows[1][2]).toBe('')
-    })
+  it('does not affect other cells', () => {
+    updateGrid('Z', 0, 0)
+    expect(getGame().grid.rows[1][2]).toBe('')
+  })
 })
 
 describe('createGridCell', () => {
-    it('creates a td with correct row and col attributes', () => {
-        const cell = createGridCell(1, 2, false)
-        expect(cell.tagName).toBe('TD')
-        expect(cell.dataset.row).toBe('1')
-        expect(cell.dataset.col).toBe('2')
-    })
+  it('creates a td with correct row and col attributes', () => {
+    const cell = createGridCell(1, 2, false)
+    expect(cell.tagName).toBe('TD')
+    expect(cell.dataset.row).toBe('1')
+    expect(cell.dataset.col).toBe('2')
+  })
 
-    it('populates cell value when stored letter exists', () => {
-        const game = makeGame()
-        game.grid.rows[0][0] = 'X'
-        setGame(game)
-        const cell = createGridCell(0, 0, true)
-        expect(cell.dataset.value).toBe('X')
-        expect(cell.classList.contains('used')).toBe(true)
-    })
+  it('populates cell value when stored letter exists', () => {
+    const game = makeGame()
+    game.grid.rows[0][0] = 'X'
+    setGame(game)
+    const cell = createGridCell(0, 0, true)
+    expect(cell.dataset.value).toBe('X')
+    expect(cell.classList.contains('used')).toBe(true)
+  })
 
-    it('leaves cell empty when stored=false', () => {
-        const game = makeGame()
-        game.grid.rows[0][0] = 'X'
-        setGame(game)
-        const cell = createGridCell(0, 0, false)
-        expect(cell.dataset.value).toBeUndefined()
-        expect(cell.classList.contains('used')).toBe(false)
-    })
+  it('leaves cell empty when stored=false', () => {
+    const game = makeGame()
+    game.grid.rows[0][0] = 'X'
+    setGame(game)
+    const cell = createGridCell(0, 0, false)
+    expect(cell.dataset.value).toBeUndefined()
+    expect(cell.classList.contains('used')).toBe(false)
+  })
 })
 
 describe('createGridRow', () => {
-    it('creates a tr with the specified number of cells', () => {
-        const row = createGridRow(4, 0, false)
-        expect(row.tagName).toBe('TR')
-        expect(row.querySelectorAll('td')).toHaveLength(4)
-    })
+  it('creates a tr with the specified number of cells', () => {
+    const row = createGridRow(4, 0, false)
+    expect(row.tagName).toBe('TR')
+    expect(row.querySelectorAll('td')).toHaveLength(4)
+  })
 })
 
 describe('addRowTop', () => {
-    it('increases grid height by 1', () => {
-        addRowTop()
-        expect(getGame().grid.height).toBe(4)
-    })
+  it('increases grid height by 1', () => {
+    addRowTop()
+    expect(getGame().grid.height).toBe(4)
+  })
 
-    it('adds a row to the top of the DOM', () => {
-        const tbody = document.querySelector('#words__grid tbody')
-        // seed a row so we can verify insertion position
-        tbody.appendChild(createGridRow(3, 0, false))
-        addRowTop()
-        expect(tbody.querySelectorAll('tr')).toHaveLength(2)
-        expect(tbody.firstChild.querySelectorAll('td')).toHaveLength(3)
-    })
+  it('adds a row to the top of the DOM', () => {
+    const tbody = document.querySelector('#words__grid tbody')
+    // seed a row so we can verify insertion position
+    tbody.appendChild(createGridRow(3, 0, false))
+    addRowTop()
+    expect(tbody.querySelectorAll('tr')).toHaveLength(2)
+    expect(tbody.firstChild.querySelectorAll('td')).toHaveLength(3)
+  })
 })
 
 describe('addRowBottom', () => {
-    it('increases grid height by 1', () => {
-        addRowBottom()
-        expect(getGame().grid.height).toBe(4)
-    })
+  it('increases grid height by 1', () => {
+    addRowBottom()
+    expect(getGame().grid.height).toBe(4)
+  })
 })
 
 describe('addColumnLeft', () => {
-    it('increases grid width by 1', () => {
-        const tbody = document.querySelector('#words__grid tbody')
-        tbody.appendChild(createGridRow(3, 0, false))
-        addColumnLeft()
-        expect(getGame().grid.width).toBe(4)
-    })
+  it('increases grid width by 1', () => {
+    const tbody = document.querySelector('#words__grid tbody')
+    tbody.appendChild(createGridRow(3, 0, false))
+    addColumnLeft()
+    expect(getGame().grid.width).toBe(4)
+  })
 })
 
 describe('addColumnRight', () => {
-    it('increases grid width by 1', () => {
-        const tbody = document.querySelector('#words__grid tbody')
-        tbody.appendChild(createGridRow(3, 0, false))
-        addColumnRight()
-        expect(getGame().grid.width).toBe(4)
-    })
+  it('increases grid width by 1', () => {
+    const tbody = document.querySelector('#words__grid tbody')
+    tbody.appendChild(createGridRow(3, 0, false))
+    addColumnRight()
+    expect(getGame().grid.width).toBe(4)
+  })
 })

--- a/test/keyboard.test.js
+++ b/test/keyboard.test.js
@@ -3,82 +3,88 @@ import { vi } from 'vitest'
 
 // Mock all modules that keyboard.js delegates to
 vi.mock('../src/scripts/game', () => ({
-    roll: vi.fn(),
+  roll: vi.fn(),
 }))
 vi.mock('../src/scripts/grid', () => ({
-    resetGrid: vi.fn(),
-    addRowTop: vi.fn(),
-    addRowBottom: vi.fn(),
-    addColumnLeft: vi.fn(),
-    addColumnRight: vi.fn(),
+  resetGrid: vi.fn(),
+  addRowTop: vi.fn(),
+  addRowBottom: vi.fn(),
+  addColumnLeft: vi.fn(),
+  addColumnRight: vi.fn(),
 }))
 vi.mock('../src/scripts/toggle', () => ({
-    toggleHeaderFooter: vi.fn(),
-    toggleButtonText: vi.fn(),
+  toggleHeaderFooter: vi.fn(),
+  toggleButtonText: vi.fn(),
 }))
 
 import { roll } from '../src/scripts/game'
-import { resetGrid, addRowTop, addRowBottom, addColumnLeft, addColumnRight } from '../src/scripts/grid'
+import {
+  resetGrid,
+  addRowTop,
+  addRowBottom,
+  addColumnLeft,
+  addColumnRight,
+} from '../src/scripts/grid'
 import { toggleHeaderFooter, toggleButtonText } from '../src/scripts/toggle'
 
 const ctrlKey = (keyCode) => {
-    const e = { ctrlKey: true, keyCode, preventDefault: vi.fn() }
-    handleKeyboard(e)
-    return e
+  const e = { ctrlKey: true, keyCode, preventDefault: vi.fn() }
+  handleKeyboard(e)
+  return e
 }
 
 beforeEach(() => {
-    vi.clearAllMocks()
+  vi.clearAllMocks()
 })
 
 describe('handleKeyboard', () => {
-    it('does nothing without ctrlKey', () => {
-        handleKeyboard({ ctrlKey: false, keyCode: 13, preventDefault: vi.fn() })
-        expect(roll).not.toHaveBeenCalled()
-    })
+  it('does nothing without ctrlKey', () => {
+    handleKeyboard({ ctrlKey: false, keyCode: 13, preventDefault: vi.fn() })
+    expect(roll).not.toHaveBeenCalled()
+  })
 
-    it('Ctrl+Enter calls roll', () => {
-        ctrlKey(13)
-        expect(roll).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+Enter calls roll', () => {
+    ctrlKey(13)
+    expect(roll).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+Home calls resetGrid', () => {
-        ctrlKey(36)
-        expect(resetGrid).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+Home calls resetGrid', () => {
+    ctrlKey(36)
+    expect(resetGrid).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+ArrowLeft calls addColumnLeft', () => {
-        ctrlKey(37)
-        expect(addColumnLeft).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+ArrowLeft calls addColumnLeft', () => {
+    ctrlKey(37)
+    expect(addColumnLeft).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+ArrowUp calls addRowTop', () => {
-        ctrlKey(38)
-        expect(addRowTop).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+ArrowUp calls addRowTop', () => {
+    ctrlKey(38)
+    expect(addRowTop).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+ArrowRight calls addColumnRight', () => {
-        ctrlKey(39)
-        expect(addColumnRight).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+ArrowRight calls addColumnRight', () => {
+    ctrlKey(39)
+    expect(addColumnRight).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+ArrowDown calls addRowBottom', () => {
-        ctrlKey(40)
-        expect(addRowBottom).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+ArrowDown calls addRowBottom', () => {
+    ctrlKey(40)
+    expect(addRowBottom).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+Delete calls toggleHeaderFooter', () => {
-        ctrlKey(46)
-        expect(toggleHeaderFooter).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+Delete calls toggleHeaderFooter', () => {
+    ctrlKey(46)
+    expect(toggleHeaderFooter).toHaveBeenCalledTimes(1)
+  })
 
-    it('Ctrl+Space calls toggleButtonText', () => {
-        ctrlKey(32)
-        expect(toggleButtonText).toHaveBeenCalledTimes(1)
-    })
+  it('Ctrl+Space calls toggleButtonText', () => {
+    ctrlKey(32)
+    expect(toggleButtonText).toHaveBeenCalledTimes(1)
+  })
 
-    it('calls preventDefault for all Ctrl shortcuts', () => {
-        const e = ctrlKey(13)
-        expect(e.preventDefault).toHaveBeenCalled()
-    })
+  it('calls preventDefault for all Ctrl shortcuts', () => {
+    const e = ctrlKey(13)
+    expect(e.preventDefault).toHaveBeenCalled()
+  })
 })

--- a/test/toggle.test.js
+++ b/test/toggle.test.js
@@ -1,90 +1,104 @@
-import { hideHeaderFooter, toggleHeaderFooter, hideButtonText, toggleButtonText, swapIcons } from '../src/scripts/toggle'
+import {
+  hideHeaderFooter,
+  toggleHeaderFooter,
+  hideButtonText,
+  toggleButtonText,
+  swapIcons,
+} from '../src/scripts/toggle'
 
 beforeEach(() => {
-    localStorage.clear()
-    document.getElementById('header').className = ''
-    document.getElementById('footer').className = ''
-    document.querySelectorAll('span.js-canHide').forEach((el) => {
-        el.className = 'js-canHide'
-    })
+  localStorage.clear()
+  document.getElementById('header').className = ''
+  document.getElementById('footer').className = ''
+  document.querySelectorAll('span.js-canHide').forEach((el) => {
+    el.className = 'js-canHide'
+  })
 })
 
 describe('hideHeaderFooter', () => {
-    it('adds visually-hidden to header and footer', () => {
-        hideHeaderFooter()
-        expect(document.getElementById('header').classList.contains('visually-hidden')).toBe(true)
-        expect(document.getElementById('footer').classList.contains('visually-hidden')).toBe(true)
-    })
+  it('adds visually-hidden to header and footer', () => {
+    hideHeaderFooter()
+    expect(
+      document.getElementById('header').classList.contains('visually-hidden'),
+    ).toBe(true)
+    expect(
+      document.getElementById('footer').classList.contains('visually-hidden'),
+    ).toBe(true)
+  })
 
-    it('sets compress in localStorage', () => {
-        hideHeaderFooter()
-        expect(localStorage.getItem('compress')).toBe('true')
-    })
+  it('sets compress in localStorage', () => {
+    hideHeaderFooter()
+    expect(localStorage.getItem('compress')).toBe('true')
+  })
 })
 
 describe('toggleHeaderFooter', () => {
-    it('hides header/footer when visible', () => {
-        toggleHeaderFooter()
-        expect(document.getElementById('header').classList.contains('visually-hidden')).toBe(true)
-    })
+  it('hides header/footer when visible', () => {
+    toggleHeaderFooter()
+    expect(
+      document.getElementById('header').classList.contains('visually-hidden'),
+    ).toBe(true)
+  })
 
-    it('shows header/footer when hidden', () => {
-        document.getElementById('header').classList.add('visually-hidden')
-        document.getElementById('footer').classList.add('visually-hidden')
-        toggleHeaderFooter()
-        expect(document.getElementById('header').classList.contains('visually-hidden')).toBe(false)
-    })
+  it('shows header/footer when hidden', () => {
+    document.getElementById('header').classList.add('visually-hidden')
+    document.getElementById('footer').classList.add('visually-hidden')
+    toggleHeaderFooter()
+    expect(
+      document.getElementById('header').classList.contains('visually-hidden'),
+    ).toBe(false)
+  })
 
-    it('removes compress from localStorage when showing', () => {
-        localStorage.setItem('compress', 'true')
-        document.getElementById('header').classList.add('visually-hidden')
-        document.getElementById('footer').classList.add('visually-hidden')
-        toggleHeaderFooter()
-        expect(localStorage.getItem('compress')).toBeNull()
-    })
+  it('removes compress from localStorage when showing', () => {
+    localStorage.setItem('compress', 'true')
+    document.getElementById('header').classList.add('visually-hidden')
+    document.getElementById('footer').classList.add('visually-hidden')
+    toggleHeaderFooter()
+    expect(localStorage.getItem('compress')).toBeNull()
+  })
 })
 
 describe('hideButtonText', () => {
-    it('adds visually-hidden to button text spans', () => {
-        hideButtonText()
-        document.querySelectorAll('span.js-canHide').forEach((el) => {
-            expect(el.classList.contains('visually-hidden')).toBe(true)
-        })
+  it('adds visually-hidden to button text spans', () => {
+    hideButtonText()
+    document.querySelectorAll('span.js-canHide').forEach((el) => {
+      expect(el.classList.contains('visually-hidden')).toBe(true)
     })
+  })
 
-    it('sets iconsOnly in localStorage', () => {
-        hideButtonText()
-        expect(localStorage.getItem('iconsOnly')).toBe('true')
-    })
+  it('sets iconsOnly in localStorage', () => {
+    hideButtonText()
+    expect(localStorage.getItem('iconsOnly')).toBe('true')
+  })
 })
 
 describe('toggleButtonText', () => {
-    it('hides button text when visible', () => {
-        toggleButtonText()
-        document.querySelectorAll('span.js-canHide').forEach((el) => {
-            expect(el.classList.contains('visually-hidden')).toBe(true)
-        })
+  it('hides button text when visible', () => {
+    toggleButtonText()
+    document.querySelectorAll('span.js-canHide').forEach((el) => {
+      expect(el.classList.contains('visually-hidden')).toBe(true)
     })
+  })
 
-    it('shows button text when hidden', () => {
-        document.querySelectorAll('span.js-canHide').forEach((el) => {
-            el.classList.add('visually-hidden')
-        })
-        toggleButtonText()
-        document.querySelectorAll('span.js-canHide').forEach((el) => {
-            expect(el.classList.contains('visually-hidden')).toBe(false)
-        })
+  it('shows button text when hidden', () => {
+    document.querySelectorAll('span.js-canHide').forEach((el) => {
+      el.classList.add('visually-hidden')
     })
+    toggleButtonText()
+    document.querySelectorAll('span.js-canHide').forEach((el) => {
+      expect(el.classList.contains('visually-hidden')).toBe(false)
+    })
+  })
 })
 
 describe('swapIcons', () => {
-    it('toggles hidden attribute on SVG children', () => {
-        const btn = document.getElementById('toggleHeaderFooter')
-        const [first, second] = btn.querySelectorAll('svg')
-        const firstWasHidden = first.hasAttribute('hidden')
-        const secondWasHidden = second.hasAttribute('hidden')
-        swapIcons(btn)
-        expect(first.hasAttribute('hidden')).toBe(!firstWasHidden)
-        expect(second.hasAttribute('hidden')).toBe(!secondWasHidden)
-    })
+  it('toggles hidden attribute on SVG children', () => {
+    const btn = document.getElementById('toggleHeaderFooter')
+    const [first, second] = btn.querySelectorAll('svg')
+    const firstWasHidden = first.hasAttribute('hidden')
+    const secondWasHidden = second.hasAttribute('hidden')
+    swapIcons(btn)
+    expect(first.hasAttribute('hidden')).toBe(!firstWasHidden)
+    expect(second.hasAttribute('hidden')).toBe(!secondWasHidden)
+  })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,44 +6,46 @@ import { dirname, resolve } from 'path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function serviceWorkerPlugin() {
-    return {
-        name: 'service-worker',
-        apply: 'build',
-        generateBundle() {
-            const sw = readFileSync(resolve(__dirname, 'src/sw.js'), 'utf8')
-                .replace('{buildtime}', Date.now().toString())
-            this.emitFile({ type: 'asset', fileName: 'sw.js', source: sw })
-        },
-    }
+  return {
+    name: 'service-worker',
+    apply: 'build',
+    generateBundle() {
+      const sw = readFileSync(resolve(__dirname, 'src/sw.js'), 'utf8').replace(
+        '{buildtime}',
+        Date.now().toString(),
+      )
+      this.emitFile({ type: 'asset', fileName: 'sw.js', source: sw })
+    },
+  }
 }
 
 export default defineConfig(({ mode }) => ({
-    root: 'src',
-    base: './',
-    server: { port: 3080 },
-    preview: { port: 3080 },
-    build: {
-        outDir: mode === 'netlify' ? '../netlify' : '../dist',
-        emptyOutDir: true,
-        rollupOptions: {
-            output: {
-                entryFileNames: 'js/[name].js',
-                chunkFileNames: 'js/[name].js',
-                assetFileNames: assetInfo =>
-                    /\.css$/i.test(assetInfo.name ?? '')
-                        ? 'css/[name][extname]'
-                        : 'assets/[name][extname]',
-            },
-        },
+  root: 'src',
+  base: './',
+  server: { port: 3080 },
+  preview: { port: 3080 },
+  build: {
+    outDir: mode === 'netlify' ? '../netlify' : '../dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'js/[name].js',
+        chunkFileNames: 'js/[name].js',
+        assetFileNames: (assetInfo) =>
+          /\.css$/i.test(assetInfo.name ?? '')
+            ? 'css/[name][extname]'
+            : 'assets/[name][extname]',
+      },
     },
-    plugins: [serviceWorkerPlugin()],
-    test: {
-        environment: 'jsdom',
-        globals: true,
-        setupFiles: ['../test/setup.js'],
-        include: ['../test/**/*.test.js'],
-        coverage: {
-            provider: 'v8',
-        },
+  },
+  plugins: [serviceWorkerPlugin()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['../test/setup.js'],
+    include: ['../test/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
     },
+  },
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,7 +184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.8.0":
+"@eslint-community/eslint-utils@npm:^4.8.0":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -644,13 +644,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rtsao/scc@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@rtsao/scc@npm:1.1.0"
-  checksum: 10c0/b5bcfb0d87f7d1c1c7c0f7693f53b07866ed9fec4c34a97a8c948fb9a7c0082e416ce4d3b60beb4f5e167cbe04cdeefbf6771320f3ede059b9ce91188c409a5b
-  languageName: node
-  linkType: hard
-
 "@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -695,13 +688,6 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
-  languageName: node
-  linkType: hard
-
-"@types/json5@npm:^0.0.29":
-  version: 0.0.29
-  resolution: "@types/json5@npm:0.0.29"
-  checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
   languageName: node
   linkType: hard
 
@@ -864,86 +850,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "array-buffer-byte-length@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    is-array-buffer: "npm:^3.0.5"
-  checksum: 10c0/74e1d2d996941c7a1badda9cabb7caab8c449db9086407cad8a1b71d2604cc8abf105db8ca4e02c04579ec58b7be40279ddb09aea4784832984485499f48432d
-  languageName: node
-  linkType: hard
-
-"array-includes@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "array-includes@npm:3.1.9"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.24.0"
-    es-object-atoms: "npm:^1.1.1"
-    get-intrinsic: "npm:^1.3.0"
-    is-string: "npm:^1.1.1"
-    math-intrinsics: "npm:^1.1.0"
-  checksum: 10c0/0235fa69078abeac05ac4250699c44996bc6f774a9cbe45db48674ce6bd142f09b327d31482ff75cf03344db4ea03eae23edb862d59378b484b47ed842574856
-  languageName: node
-  linkType: hard
-
-"array.prototype.findlastindex@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "array.prototype.findlastindex@npm:1.2.6"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.9"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    es-shim-unscopables: "npm:^1.1.0"
-  checksum: 10c0/82559310d2e57ec5f8fc53d7df420e3abf0ba497935de0a5570586035478ba7d07618cb18e2d4ada2da514c8fb98a034aaf5c06caa0a57e2f7f4c4adedef5956
-  languageName: node
-  linkType: hard
-
-"array.prototype.flat@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "array.prototype.flat@npm:1.3.3"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.5"
-    es-shim-unscopables: "npm:^1.0.2"
-  checksum: 10c0/d90e04dfbc43bb96b3d2248576753d1fb2298d2d972e29ca7ad5ec621f0d9e16ff8074dae647eac4f31f4fb7d3f561a7ac005fb01a71f51705a13b5af06a7d8a
-  languageName: node
-  linkType: hard
-
-"array.prototype.flatmap@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "array.prototype.flatmap@npm:1.3.3"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.5"
-    es-shim-unscopables: "npm:^1.0.2"
-  checksum: 10c0/ba899ea22b9dc9bf276e773e98ac84638ed5e0236de06f13d63a90b18ca9e0ec7c97d622d899796e3773930b946cd2413d098656c0c5d8cc58c6f25c21e6bd54
-  languageName: node
-  linkType: hard
-
-"arraybuffer.prototype.slice@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "arraybuffer.prototype.slice@npm:1.0.4"
-  dependencies:
-    array-buffer-byte-length: "npm:^1.0.1"
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.5"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    is-array-buffer: "npm:^3.0.4"
-  checksum: 10c0/2f2459caa06ae0f7f615003f9104b01f6435cc803e11bd2a655107d52a1781dc040532dc44d93026b694cc18793993246237423e13a5337e86b43ed604932c06
-  languageName: node
-  linkType: hard
-
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -959,29 +865,6 @@ __metadata:
     estree-walker: "npm:^3.0.3"
     js-tokens: "npm:^10.0.0"
   checksum: 10c0/35e57b754ba63287358094d4f7ae8de2de27286fb4e76a1fbf28b2e67e3b670b59c3f511882473d0fd2cdbaa260062e3cd4f216b724c70032e2b09e5cebbd618
-  languageName: node
-  linkType: hard
-
-"async-function@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "async-function@npm:1.0.0"
-  checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
-  languageName: node
-  linkType: hard
-
-"async-generator-function@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "async-generator-function@npm:1.0.0"
-  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
-  languageName: node
-  linkType: hard
-
-"available-typed-arrays@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "available-typed-arrays@npm:1.0.7"
-  dependencies:
-    possible-typed-array-names: "npm:^1.0.0"
-  checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
   languageName: node
   linkType: hard
 
@@ -1008,38 +891,6 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
-  languageName: node
-  linkType: hard
-
-"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "call-bind-apply-helpers@npm:1.0.2"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
-  languageName: node
-  linkType: hard
-
-"call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "call-bind@npm:1.0.9"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.2"
-    es-define-property: "npm:^1.0.1"
-    get-intrinsic: "npm:^1.3.0"
-    set-function-length: "npm:^1.2.2"
-  checksum: 10c0/a6621f6da1444481919ce3b4983dff725691e0754d3507ae483ce56e54985f2da7d6f1df512c56dbf28660745cf1ca52553f1fc9aef5557f3ce353ef14fab714
-  languageName: node
-  linkType: hard
-
-"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "call-bound@npm:1.0.4"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.2"
-    get-intrinsic: "npm:^1.3.0"
-  checksum: 10c0/f4796a6a0941e71c766aea672f63b72bc61234c4f4964dc6d7606e3664c307e7d77845328a8f3359ce39ddb377fed67318f9ee203dea1d47e46165dcf2917644
   languageName: node
   linkType: hard
 
@@ -1144,48 +995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-view-buffer@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "data-view-buffer@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    is-data-view: "npm:^1.0.2"
-  checksum: 10c0/7986d40fc7979e9e6241f85db8d17060dd9a71bd53c894fa29d126061715e322a4cd47a00b0b8c710394854183d4120462b980b8554012acc1c0fa49df7ad38c
-  languageName: node
-  linkType: hard
-
-"data-view-byte-length@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "data-view-byte-length@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    is-data-view: "npm:^1.0.2"
-  checksum: 10c0/f8a4534b5c69384d95ac18137d381f18a5cfae1f0fc1df0ef6feef51ef0d568606d970b69e02ea186c6c0f0eac77fe4e6ad96fec2569cc86c3afcc7475068c55
-  languageName: node
-  linkType: hard
-
-"data-view-byte-offset@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "data-view-byte-offset@npm:1.0.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    is-data-view: "npm:^1.0.1"
-  checksum: 10c0/fa7aa40078025b7810dcffc16df02c480573b7b53ef1205aa6a61533011005c1890e5ba17018c692ce7c900212b547262d33279fde801ad9843edc0863bf78c4
-  languageName: node
-  linkType: hard
-
-"debug@npm:^3.2.7":
-  version: 3.2.7
-  resolution: "debug@npm:3.2.7"
-  dependencies:
-    ms: "npm:^2.1.1"
-  checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
-  languageName: node
-  linkType: hard
-
 "debug@npm:^4.3.1, debug@npm:^4.3.2":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -1212,52 +1021,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "define-data-property@npm:1.1.4"
-  dependencies:
-    es-define-property: "npm:^1.0.0"
-    es-errors: "npm:^1.3.0"
-    gopd: "npm:^1.0.1"
-  checksum: 10c0/dea0606d1483eb9db8d930d4eac62ca0fa16738b0b3e07046cddfacf7d8c868bbe13fa0cb263eb91c7d0d527960dc3f2f2471a69ed7816210307f6744fe62e37
-  languageName: node
-  linkType: hard
-
-"define-properties@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "define-properties@npm:1.2.1"
-  dependencies:
-    define-data-property: "npm:^1.0.1"
-    has-property-descriptors: "npm:^1.0.0"
-    object-keys: "npm:^1.1.1"
-  checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
-  languageName: node
-  linkType: hard
-
 "detect-libc@npm:^2.0.3":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
-  languageName: node
-  linkType: hard
-
-"doctrine@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "doctrine@npm:2.1.0"
-  dependencies:
-    esutils: "npm:^2.0.2"
-  checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
-  languageName: node
-  linkType: hard
-
-"dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "dunder-proto@npm:1.0.1"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    gopd: "npm:^1.2.0"
-  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
   languageName: node
   linkType: hard
 
@@ -1275,127 +1042,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0":
-  version: 1.24.2
-  resolution: "es-abstract@npm:1.24.2"
-  dependencies:
-    array-buffer-byte-length: "npm:^1.0.2"
-    arraybuffer.prototype.slice: "npm:^1.0.4"
-    available-typed-arrays: "npm:^1.0.7"
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    data-view-buffer: "npm:^1.0.2"
-    data-view-byte-length: "npm:^1.0.2"
-    data-view-byte-offset: "npm:^1.0.1"
-    es-define-property: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    es-set-tostringtag: "npm:^2.1.0"
-    es-to-primitive: "npm:^1.3.0"
-    function.prototype.name: "npm:^1.1.8"
-    get-intrinsic: "npm:^1.3.0"
-    get-proto: "npm:^1.0.1"
-    get-symbol-description: "npm:^1.1.0"
-    globalthis: "npm:^1.0.4"
-    gopd: "npm:^1.2.0"
-    has-property-descriptors: "npm:^1.0.2"
-    has-proto: "npm:^1.2.0"
-    has-symbols: "npm:^1.1.0"
-    hasown: "npm:^2.0.2"
-    internal-slot: "npm:^1.1.0"
-    is-array-buffer: "npm:^3.0.5"
-    is-callable: "npm:^1.2.7"
-    is-data-view: "npm:^1.0.2"
-    is-negative-zero: "npm:^2.0.3"
-    is-regex: "npm:^1.2.1"
-    is-set: "npm:^2.0.3"
-    is-shared-array-buffer: "npm:^1.0.4"
-    is-string: "npm:^1.1.1"
-    is-typed-array: "npm:^1.1.15"
-    is-weakref: "npm:^1.1.1"
-    math-intrinsics: "npm:^1.1.0"
-    object-inspect: "npm:^1.13.4"
-    object-keys: "npm:^1.1.1"
-    object.assign: "npm:^4.1.7"
-    own-keys: "npm:^1.0.1"
-    regexp.prototype.flags: "npm:^1.5.4"
-    safe-array-concat: "npm:^1.1.3"
-    safe-push-apply: "npm:^1.0.0"
-    safe-regex-test: "npm:^1.1.0"
-    set-proto: "npm:^1.0.0"
-    stop-iteration-iterator: "npm:^1.1.0"
-    string.prototype.trim: "npm:^1.2.10"
-    string.prototype.trimend: "npm:^1.0.9"
-    string.prototype.trimstart: "npm:^1.0.8"
-    typed-array-buffer: "npm:^1.0.3"
-    typed-array-byte-length: "npm:^1.0.3"
-    typed-array-byte-offset: "npm:^1.0.4"
-    typed-array-length: "npm:^1.0.7"
-    unbox-primitive: "npm:^1.1.0"
-    which-typed-array: "npm:^1.1.19"
-  checksum: 10c0/67a5bf21ef5c7d775e6f6131a836323900b4d87194cf544394ac68fe31c57fa53828b978af4a4f551ef307f83a2f910a16b6b982760ad3ddc3dc471f98d5fd1b
-  languageName: node
-  linkType: hard
-
-"es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "es-define-property@npm:1.0.1"
-  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
-  languageName: node
-  linkType: hard
-
-"es-errors@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "es-errors@npm:1.3.0"
-  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
-  languageName: node
-  linkType: hard
-
 "es-module-lexer@npm:^2.0.0":
   version: 2.1.0
   resolution: "es-module-lexer@npm:2.1.0"
   checksum: 10c0/93bcf2454fa72d67fe3ccd0abef8ce7933f5840a319513418a643dd8e9c6aa8f49709cecfae02ded722805dd327232d30723a807cc52e6809d6ac697c62c29fb
-  languageName: node
-  linkType: hard
-
-"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "es-object-atoms@npm:1.1.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
-  languageName: node
-  linkType: hard
-
-"es-shim-unscopables@npm:^1.0.2, es-shim-unscopables@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "es-shim-unscopables@npm:1.1.0"
-  dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/1b9702c8a1823fc3ef39035a4e958802cf294dd21e917397c561d0b3e195f383b978359816b1732d02b255ccf63e1e4815da0065b95db8d7c992037be3bbbcdb
-  languageName: node
-  linkType: hard
-
-"es-to-primitive@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "es-to-primitive@npm:1.3.0"
-  dependencies:
-    is-callable: "npm:^1.2.7"
-    is-date-object: "npm:^1.0.5"
-    is-symbol: "npm:^1.0.4"
-  checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
   languageName: node
   linkType: hard
 
@@ -1406,94 +1056,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.9":
-  version: 0.3.10
-  resolution: "eslint-import-resolver-node@npm:0.3.10"
-  dependencies:
-    debug: "npm:^3.2.7"
-    is-core-module: "npm:^2.16.1"
-    resolve: "npm:^2.0.0-next.6"
-  checksum: 10c0/2e05bdb148fe10a25b9a6fec3c4986a2e09e98bb99208491df82a9df7725f7bb312482d585404c440d42e58ab60debe7a48d9c992191851385b18d33a146e3c3
-  languageName: node
-  linkType: hard
-
-"eslint-module-utils@npm:^2.12.1":
-  version: 2.12.1
-  resolution: "eslint-module-utils@npm:2.12.1"
-  dependencies:
-    debug: "npm:^3.2.7"
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10c0/6f4efbe7a91ae49bf67b4ab3644cb60bc5bd7db4cb5521de1b65be0847ffd3fb6bce0dd68f0995e1b312d137f768e2a1f842ee26fe73621afa05f850628fdc40
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-es@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "eslint-plugin-es@npm:3.0.1"
-  dependencies:
-    eslint-utils: "npm:^2.0.0"
-    regexpp: "npm:^3.0.0"
+"eslint-config-prettier@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
   peerDependencies:
-    eslint: ">=4.19.1"
-  checksum: 10c0/12ae730aa9603e680af048e1653aac15e529411b68b8d0da6e290700b17c695485af7c3f5360f531f80970786cab7288c2c1d4a58c35ec1bb89649897c016c4a
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-import@npm:^2.32.0":
-  version: 2.32.0
-  resolution: "eslint-plugin-import@npm:2.32.0"
-  dependencies:
-    "@rtsao/scc": "npm:^1.1.0"
-    array-includes: "npm:^3.1.9"
-    array.prototype.findlastindex: "npm:^1.2.6"
-    array.prototype.flat: "npm:^1.3.3"
-    array.prototype.flatmap: "npm:^1.3.3"
-    debug: "npm:^3.2.7"
-    doctrine: "npm:^2.1.0"
-    eslint-import-resolver-node: "npm:^0.3.9"
-    eslint-module-utils: "npm:^2.12.1"
-    hasown: "npm:^2.0.2"
-    is-core-module: "npm:^2.16.1"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^3.1.2"
-    object.fromentries: "npm:^2.0.8"
-    object.groupby: "npm:^1.0.3"
-    object.values: "npm:^1.2.1"
-    semver: "npm:^6.3.1"
-    string.prototype.trimend: "npm:^1.0.9"
-    tsconfig-paths: "npm:^3.15.0"
-  peerDependencies:
-    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
-  checksum: 10c0/bfb1b8fc8800398e62ddfefbf3638d185286edfed26dfe00875cc2846d954491b4f5112457831588b757fa789384e1ae585f812614c4797f0499fa234fd4a48b
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-node@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "eslint-plugin-node@npm:11.1.0"
-  dependencies:
-    eslint-plugin-es: "npm:^3.0.0"
-    eslint-utils: "npm:^2.0.0"
-    ignore: "npm:^5.1.1"
-    minimatch: "npm:^3.0.4"
-    resolve: "npm:^1.10.1"
-    semver: "npm:^6.1.0"
-  peerDependencies:
-    eslint: ">=5.16.0"
-  checksum: 10c0/c7716adac4020cb852fd2410dcd8bdb13a227004de77f96d7f9806d0cf2274f24e0920a7ca73bcd72d90003696c1f17fdd9fe3ca218e64ee03dc2b840e4416fa
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-promise@npm:^7.2.1":
-  version: 7.3.0
-  resolution: "eslint-plugin-promise@npm:7.3.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-  peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
-  checksum: 10c0/417d3ab57895143bd687aa840804d0d7bbe70227242530eea7d4af7ae680a67d6872ce3a2adcc36dec29009d1861c63717c5887c30da1887153c8e5a181f3eb5
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
   languageName: node
   linkType: hard
 
@@ -1504,22 +1074,6 @@ __metadata:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
   checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
-  languageName: node
-  linkType: hard
-
-"eslint-utils@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "eslint-utils@npm:2.1.0"
-  dependencies:
-    eslint-visitor-keys: "npm:^1.1.0"
-  checksum: 10c0/69521c5d6569384b24093125d037ba238d3d6e54367f7143af9928f5286369e912c26cad5016d730c0ffb9797ac9e83831059d7f1d863f7dc84330eb02414611
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^1.1.0":
-  version: 1.3.0
-  resolution: "eslint-visitor-keys@npm:1.3.0"
-  checksum: 10c0/10c91fdbbe36810dd4308e57f9a8bc7177188b2a70247e54e3af1fa05ebc66414ae6fd4ce3c6c6821591f43a556e9037bc6b071122e099b5f8b7d2f76df553e3
   languageName: node
   linkType: hard
 
@@ -1721,15 +1275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"for-each@npm:^0.3.3, for-each@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "for-each@npm:0.3.5"
-  dependencies:
-    is-callable: "npm:^1.2.7"
-  checksum: 10c0/0e0b50f6a843a282637d43674d1fb278dda1dd85f4f99b640024cfb10b85058aac0cc781bf689d5fe50b4b7f638e91e548560723a4e76e04fe96ae35ef039cee
-  languageName: node
-  linkType: hard
-
 "fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
@@ -1746,83 +1291,6 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"function-bind@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "function-bind@npm:1.1.2"
-  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
-  languageName: node
-  linkType: hard
-
-"function.prototype.name@npm:^1.1.6, function.prototype.name@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "function.prototype.name@npm:1.1.8"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.3"
-    define-properties: "npm:^1.2.1"
-    functions-have-names: "npm:^1.2.3"
-    hasown: "npm:^2.0.2"
-    is-callable: "npm:^1.2.7"
-  checksum: 10c0/e920a2ab52663005f3cbe7ee3373e3c71c1fb5558b0b0548648cdf3e51961085032458e26c71ff1a8c8c20e7ee7caeb03d43a5d1fa8610c459333323a2e71253
-  languageName: node
-  linkType: hard
-
-"functions-have-names@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "functions-have-names@npm:1.2.3"
-  checksum: 10c0/33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
-  languageName: node
-  linkType: hard
-
-"generator-function@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "generator-function@npm:2.0.1"
-  checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
-  languageName: node
-  linkType: hard
-
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "get-intrinsic@npm:1.3.1"
-  dependencies:
-    async-function: "npm:^1.0.0"
-    async-generator-function: "npm:^1.0.0"
-    call-bind-apply-helpers: "npm:^1.0.2"
-    es-define-property: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    function-bind: "npm:^1.1.2"
-    generator-function: "npm:^2.0.0"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    has-symbols: "npm:^1.1.0"
-    hasown: "npm:^2.0.2"
-    math-intrinsics: "npm:^1.1.0"
-  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
-  languageName: node
-  linkType: hard
-
-"get-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "get-proto@npm:1.0.1"
-  dependencies:
-    dunder-proto: "npm:^1.0.1"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
-  languageName: node
-  linkType: hard
-
-"get-symbol-description@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "get-symbol-description@npm:1.1.0"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-  checksum: 10c0/d6a7d6afca375779a4b307738c9e80dbf7afc0bdbe5948768d54ab9653c865523d8920e670991a925936eb524b7cb6a6361d199a760b21d0ca7620194455aa4b
   languageName: node
   linkType: hard
 
@@ -1849,23 +1317,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "globalthis@npm:1.0.4"
-  dependencies:
-    define-properties: "npm:^1.2.1"
-    gopd: "npm:^1.0.1"
-  checksum: 10c0/9d156f313af79d80b1566b93e19285f481c591ad6d0d319b4be5e03750d004dde40a39a0f26f7e635f9007a3600802f53ecd85a759b86f109e80a5f705e01846
-  languageName: node
-  linkType: hard
-
-"gopd@npm:^1.0.1, gopd@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "gopd@npm:1.2.0"
-  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -1873,60 +1324,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-bigints@npm:^1.0.2":
-  version: 1.1.0
-  resolution: "has-bigints@npm:1.1.0"
-  checksum: 10c0/2de0cdc4a1ccf7a1e75ffede1876994525ac03cc6f5ae7392d3415dd475cd9eee5bceec63669ab61aa997ff6cceebb50ef75561c7002bed8988de2b9d1b40788
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
-"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-property-descriptors@npm:1.0.2"
-  dependencies:
-    es-define-property: "npm:^1.0.0"
-  checksum: 10c0/253c1f59e80bb476cf0dde8ff5284505d90c3bdb762983c3514d36414290475fe3fd6f574929d84de2a8eec00d35cf07cb6776205ff32efd7c50719125f00236
-  languageName: node
-  linkType: hard
-
-"has-proto@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "has-proto@npm:1.2.0"
-  dependencies:
-    dunder-proto: "npm:^1.0.0"
-  checksum: 10c0/46538dddab297ec2f43923c3d35237df45d8c55a6fc1067031e04c13ed8a9a8f94954460632fd4da84c31a1721eefee16d901cbb1ae9602bab93bb6e08f93b95
-  languageName: node
-  linkType: hard
-
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "has-symbols@npm:1.1.0"
-  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2"
-  dependencies:
-    has-symbols: "npm:^1.0.3"
-  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
-  languageName: node
-  linkType: hard
-
-"hasown@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "hasown@npm:2.0.3"
-  dependencies:
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/f5eb28c3fd0d3e4facd821c1eeee3836c37b70ab0b0fc532e8a39976e18fef43652415dadc52f8c7a5ff6d5ac93b7bef128789aa6f90f4e9b9a9083dce74ab38
   languageName: node
   linkType: hard
 
@@ -1946,7 +1347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -1977,123 +1378,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "internal-slot@npm:1.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    hasown: "npm:^2.0.2"
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/03966f5e259b009a9bf1a78d60da920df198af4318ec004f57b8aef1dd3fe377fbc8cce63a96e8c810010302654de89f9e19de1cd8ad0061d15be28a695465c7
-  languageName: node
-  linkType: hard
-
-"is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "is-array-buffer@npm:3.0.5"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.3"
-    get-intrinsic: "npm:^1.2.6"
-  checksum: 10c0/c5c9f25606e86dbb12e756694afbbff64bc8b348d1bc989324c037e1068695131930199d6ad381952715dad3a9569333817f0b1a72ce5af7f883ce802e49c83d
-  languageName: node
-  linkType: hard
-
-"is-async-function@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "is-async-function@npm:2.1.1"
-  dependencies:
-    async-function: "npm:^1.0.0"
-    call-bound: "npm:^1.0.3"
-    get-proto: "npm:^1.0.1"
-    has-tostringtag: "npm:^1.0.2"
-    safe-regex-test: "npm:^1.1.0"
-  checksum: 10c0/d70c236a5e82de6fc4d44368ffd0c2fee2b088b893511ce21e679da275a5ecc6015ff59a7d7e1bdd7ca39f71a8dbdd253cf8cce5c6b3c91cdd5b42b5ce677298
-  languageName: node
-  linkType: hard
-
-"is-bigint@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-bigint@npm:1.1.0"
-  dependencies:
-    has-bigints: "npm:^1.0.2"
-  checksum: 10c0/f4f4b905ceb195be90a6ea7f34323bf1c18e3793f18922e3e9a73c684c29eeeeff5175605c3a3a74cc38185fe27758f07efba3dbae812e5c5afbc0d2316b40e4
-  languageName: node
-  linkType: hard
-
-"is-boolean-object@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "is-boolean-object@npm:1.2.2"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/36ff6baf6bd18b3130186990026f5a95c709345c39cd368468e6c1b6ab52201e9fd26d8e1f4c066357b4938b0f0401e1a5000e08257787c1a02f3a719457001e
-  languageName: node
-  linkType: hard
-
-"is-callable@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "is-callable@npm:1.2.7"
-  checksum: 10c0/ceebaeb9d92e8adee604076971dd6000d38d6afc40bb843ea8e45c5579b57671c3f3b50d7f04869618242c6cee08d1b67806a8cb8edaaaf7c0748b3720d6066f
-  languageName: node
-  linkType: hard
-
-"is-core-module@npm:^2.16.1":
-  version: 2.16.1
-  resolution: "is-core-module@npm:2.16.1"
-  dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
-  languageName: node
-  linkType: hard
-
-"is-data-view@npm:^1.0.1, is-data-view@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "is-data-view@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    get-intrinsic: "npm:^1.2.6"
-    is-typed-array: "npm:^1.1.13"
-  checksum: 10c0/ef3548a99d7e7f1370ce21006baca6d40c73e9f15c941f89f0049c79714c873d03b02dae1c64b3f861f55163ecc16da06506c5b8a1d4f16650b3d9351c380153
-  languageName: node
-  linkType: hard
-
-"is-date-object@npm:^1.0.5, is-date-object@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-date-object@npm:1.1.0"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/1a4d199c8e9e9cac5128d32e6626fa7805175af9df015620ac0d5d45854ccf348ba494679d872d37301032e35a54fc7978fba1687e8721b2139aea7870cafa2f
-  languageName: node
-  linkType: hard
-
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: 10c0/5487da35691fbc339700bbb2730430b07777a3c21b9ebaecb3072512dfd7b4ba78ac2381a87e8d78d20ea08affb3f1971b4af629173a6bf435ff8a4c47747912
-  languageName: node
-  linkType: hard
-
-"is-finalizationregistry@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "is-finalizationregistry@npm:1.1.1"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-  checksum: 10c0/818dff679b64f19e228a8205a1e2d09989a98e98def3a817f889208cfcbf918d321b251aadf2c05918194803ebd2eb01b14fc9d0b2bea53d984f4137bfca5e97
-  languageName: node
-  linkType: hard
-
-"is-generator-function@npm:^1.0.10":
-  version: 1.1.2
-  resolution: "is-generator-function@npm:1.1.2"
-  dependencies:
-    call-bound: "npm:^1.0.4"
-    generator-function: "npm:^2.0.0"
-    get-proto: "npm:^1.0.1"
-    has-tostringtag: "npm:^1.0.2"
-    safe-regex-test: "npm:^1.1.0"
-  checksum: 10c0/83da102e89c3e3b71d67b51d47c9f9bc862bceb58f87201727e27f7fa19d1d90b0ab223644ecaee6fc6e3d2d622bb25c966fbdaf87c59158b01ce7c0fe2fa372
   languageName: node
   linkType: hard
 
@@ -2106,125 +1394,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "is-map@npm:2.0.3"
-  checksum: 10c0/2c4d431b74e00fdda7162cd8e4b763d6f6f217edf97d4f8538b94b8702b150610e2c64961340015fe8df5b1fcee33ccd2e9b62619c4a8a3a155f8de6d6d355fc
-  languageName: node
-  linkType: hard
-
-"is-negative-zero@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "is-negative-zero@npm:2.0.3"
-  checksum: 10c0/bcdcf6b8b9714063ffcfa9929c575ac69bfdabb8f4574ff557dfc086df2836cf07e3906f5bbc4f2a5c12f8f3ba56af640c843cdfc74da8caed86c7c7d66fd08e
-  languageName: node
-  linkType: hard
-
-"is-number-object@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-number-object@npm:1.1.1"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/97b451b41f25135ff021d85c436ff0100d84a039bb87ffd799cbcdbea81ef30c464ced38258cdd34f080be08fc3b076ca1f472086286d2aa43521d6ec6a79f53
-  languageName: node
-  linkType: hard
-
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
-  languageName: node
-  linkType: hard
-
-"is-regex@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "is-regex@npm:1.2.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    gopd: "npm:^1.2.0"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/1d3715d2b7889932349241680032e85d0b492cfcb045acb75ffc2c3085e8d561184f1f7e84b6f8321935b4aea39bc9c6ba74ed595b57ce4881a51dfdbc214e04
-  languageName: node
-  linkType: hard
-
-"is-set@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "is-set@npm:2.0.3"
-  checksum: 10c0/f73732e13f099b2dc879c2a12341cfc22ccaca8dd504e6edae26484bd5707a35d503fba5b4daad530a9b088ced1ae6c9d8200fd92e09b428fe14ea79ce8080b7
-  languageName: node
-  linkType: hard
-
-"is-shared-array-buffer@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "is-shared-array-buffer@npm:1.0.4"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-  checksum: 10c0/65158c2feb41ff1edd6bbd6fd8403a69861cf273ff36077982b5d4d68e1d59278c71691216a4a64632bd76d4792d4d1d2553901b6666d84ade13bba5ea7bc7db
-  languageName: node
-  linkType: hard
-
-"is-string@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-string@npm:1.1.1"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/2f518b4e47886bb81567faba6ffd0d8a8333cf84336e2e78bf160693972e32ad00fe84b0926491cc598dee576fdc55642c92e62d0cbe96bf36f643b6f956f94d
-  languageName: node
-  linkType: hard
-
-"is-symbol@npm:^1.0.4, is-symbol@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-symbol@npm:1.1.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    has-symbols: "npm:^1.1.0"
-    safe-regex-test: "npm:^1.1.0"
-  checksum: 10c0/f08f3e255c12442e833f75a9e2b84b2d4882fdfd920513cf2a4a2324f0a5b076c8fd913778e3ea5d258d5183e9d92c0cd20e04b03ab3df05316b049b2670af1e
-  languageName: node
-  linkType: hard
-
-"is-typed-array@npm:^1.1.13, is-typed-array@npm:^1.1.14, is-typed-array@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "is-typed-array@npm:1.1.15"
-  dependencies:
-    which-typed-array: "npm:^1.1.16"
-  checksum: 10c0/415511da3669e36e002820584e264997ffe277ff136643a3126cc949197e6ca3334d0f12d084e83b1994af2e9c8141275c741cf2b7da5a2ff62dd0cac26f76c4
-  languageName: node
-  linkType: hard
-
-"is-weakmap@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "is-weakmap@npm:2.0.2"
-  checksum: 10c0/443c35bb86d5e6cc5929cd9c75a4024bb0fff9586ed50b092f94e700b89c43a33b186b76dbc6d54f3d3d09ece689ab38dcdc1af6a482cbe79c0f2da0a17f1299
-  languageName: node
-  linkType: hard
-
-"is-weakref@npm:^1.0.2, is-weakref@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-weakref@npm:1.1.1"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-  checksum: 10c0/8e0a9c07b0c780949a100e2cab2b5560a48ecd4c61726923c1a9b77b6ab0aa0046c9e7fb2206042296817045376dee2c8ab1dabe08c7c3dfbf195b01275a085b
-  languageName: node
-  linkType: hard
-
-"is-weakset@npm:^2.0.3":
-  version: 2.0.4
-  resolution: "is-weakset@npm:2.0.4"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    get-intrinsic: "npm:^1.2.6"
-  checksum: 10c0/6491eba08acb8dc9532da23cb226b7d0192ede0b88f16199e592e4769db0a077119c1f5d2283d1e0d16d739115f70046e887e477eb0e66cd90e1bb29f28ba647
-  languageName: node
-  linkType: hard
-
-"isarray@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "isarray@npm:2.0.5"
-  checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
   languageName: node
   linkType: hard
 
@@ -2340,17 +1513,6 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
-  languageName: node
-  linkType: hard
-
-"json5@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "json5@npm:1.0.2"
-  dependencies:
-    minimist: "npm:^1.2.0"
-  bin:
-    json5: lib/cli.js
-  checksum: 10c0/9ee316bf21f000b00752e6c2a3b79ecf5324515a5c60ee88983a1910a45426b643a4f3461657586e8aeca87aaf96f0a519b0516d2ae527a6c3e7eed80f68717f
   languageName: node
   linkType: hard
 
@@ -2545,13 +1707,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "math-intrinsics@npm:1.1.0"
-  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
-  languageName: node
-  linkType: hard
-
 "mdn-data@npm:2.27.1":
   version: 2.27.1
   resolution: "mdn-data@npm:2.27.1"
@@ -2559,19 +1714,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
+"minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
-  languageName: node
-  linkType: hard
-
-"minimist@npm:^1.2.0, minimist@npm:^1.2.6":
-  version: 1.2.8
-  resolution: "minimist@npm:1.2.8"
-  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
   languageName: node
   linkType: hard
 
@@ -2591,7 +1739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.1, ms@npm:^2.1.3":
+"ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -2620,18 +1768,6 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/fb32a206276d608037fa1bcd7e9921e177fe992fc610d098aa3128baca3c0050fc1e014fa007e9b3874cf865ddb4f5bd9f43ccb7cbbbe4efaff6a83e920b17e9
-  languageName: node
-  linkType: hard
-
-"node-exports-info@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "node-exports-info@npm:1.6.0"
-  dependencies:
-    array.prototype.flatmap: "npm:^1.3.3"
-    es-errors: "npm:^1.3.0"
-    object.entries: "npm:^1.1.9"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/3613f21c60b047e66f168d3499a6be0060d89fb01ddceaa7032c2fb318aff12e4b9b111449c1a9aeb3b848bfdc1d4b6bc8fab327af692319597d21a1e7063692
   languageName: node
   linkType: hard
 
@@ -2666,81 +1802,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
-  version: 1.13.4
-  resolution: "object-inspect@npm:1.13.4"
-  checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
-  languageName: node
-  linkType: hard
-
-"object-keys@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "object-keys@npm:1.1.1"
-  checksum: 10c0/b11f7ccdbc6d406d1f186cdadb9d54738e347b2692a14439ca5ac70c225fa6db46db809711b78589866d47b25fc3e8dee0b4c722ac751e11180f9380e3d8601d
-  languageName: node
-  linkType: hard
-
-"object.assign@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "object.assign@npm:4.1.7"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.3"
-    define-properties: "npm:^1.2.1"
-    es-object-atoms: "npm:^1.0.0"
-    has-symbols: "npm:^1.1.0"
-    object-keys: "npm:^1.1.1"
-  checksum: 10c0/3b2732bd860567ea2579d1567525168de925a8d852638612846bd8082b3a1602b7b89b67b09913cbb5b9bd6e95923b2ae73580baa9d99cb4e990564e8cbf5ddc
-  languageName: node
-  linkType: hard
-
-"object.entries@npm:^1.1.9":
-  version: 1.1.9
-  resolution: "object.entries@npm:1.1.9"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-object-atoms: "npm:^1.1.1"
-  checksum: 10c0/d4b8c1e586650407da03370845f029aa14076caca4e4d4afadbc69cfb5b78035fd3ee7be417141abdb0258fa142e59b11923b4c44d8b1255b28f5ffcc50da7db
-  languageName: node
-  linkType: hard
-
-"object.fromentries@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "object.fromentries@npm:2.0.8"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/cd4327e6c3369cfa805deb4cbbe919bfb7d3aeebf0bcaba291bb568ea7169f8f8cdbcabe2f00b40db0c20cd20f08e11b5f3a5a36fb7dd3fe04850c50db3bf83b
-  languageName: node
-  linkType: hard
-
-"object.groupby@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "object.groupby@npm:1.0.3"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-  checksum: 10c0/60d0455c85c736fbfeda0217d1a77525956f76f7b2495edeca9e9bbf8168a45783199e77b894d30638837c654d0cc410e0e02cbfcf445bc8de71c3da1ede6a9c
-  languageName: node
-  linkType: hard
-
-"object.values@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "object.values@npm:1.2.1"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.3"
-    define-properties: "npm:^1.2.1"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/3c47814fdc64842ae3d5a74bc9d06bdd8d21563c04d9939bf6716a9c00596a4ebc342552f8934013d1ec991c74e3671b26710a0c51815f0b603795605ab6b2c9
-  languageName: node
-  linkType: hard
-
 "obug@npm:^2.1.1":
   version: 2.1.1
   resolution: "obug@npm:2.1.1"
@@ -2759,17 +1820,6 @@ __metadata:
     type-check: "npm:^0.4.0"
     word-wrap: "npm:^1.2.5"
   checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
-  languageName: node
-  linkType: hard
-
-"own-keys@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "own-keys@npm:1.0.1"
-  dependencies:
-    get-intrinsic: "npm:^1.2.6"
-    object-keys: "npm:^1.1.1"
-    safe-push-apply: "npm:^1.0.0"
-  checksum: 10c0/6dfeb3455bff92ec3f16a982d4e3e65676345f6902d9f5ded1d8265a6318d0200ce461956d6d1c70053c7fe9f9fe65e552faac03f8140d37ef0fdd108e67013a
   languageName: node
   linkType: hard
 
@@ -2823,13 +1873,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "path-parse@npm:1.0.7"
-  checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
-  languageName: node
-  linkType: hard
-
 "pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
@@ -2851,13 +1894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"possible-typed-array-names@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "possible-typed-array-names@npm:1.1.0"
-  checksum: 10c0/c810983414142071da1d644662ce4caebce890203eb2bc7bf119f37f3fe5796226e117e6cca146b521921fa6531072674174a3325066ac66fce089a53e1e5196
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.5.10":
   version: 8.5.13
   resolution: "postcss@npm:8.5.13"
@@ -2873,6 +1909,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "prettier@npm:3.8.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/754816fd7593eb80f6376d7476d463e832c38a12f32775a82683adb6e35b772b1f484d65f19401507b983a8c8a7cd5a4a9f12006bd56491e8f35503473f77473
   languageName: node
   linkType: hard
 
@@ -2897,43 +1942,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
-  version: 1.0.10
-  resolution: "reflect.getprototypeof@npm:1.0.10"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.9"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.0.0"
-    get-intrinsic: "npm:^1.2.7"
-    get-proto: "npm:^1.0.1"
-    which-builtin-type: "npm:^1.2.1"
-  checksum: 10c0/7facec28c8008876f8ab98e80b7b9cb4b1e9224353fd4756dda5f2a4ab0d30fa0a5074777c6df24e1e0af463a2697513b0a11e548d99cf52f21f7bc6ba48d3ac
-  languageName: node
-  linkType: hard
-
-"regexp.prototype.flags@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "regexp.prototype.flags@npm:1.5.4"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-errors: "npm:^1.3.0"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    set-function-name: "npm:^2.0.2"
-  checksum: 10c0/83b88e6115b4af1c537f8dabf5c3744032cb875d63bc05c288b1b8c0ef37cbe55353f95d8ca817e8843806e3e150b118bc624e4279b24b4776b4198232735a77
-  languageName: node
-  linkType: hard
-
-"regexpp@npm:^3.0.0":
-  version: 3.2.0
-  resolution: "regexpp@npm:3.2.0"
-  checksum: 10c0/d1da82385c8754a1681416b90b9cca0e21b4a2babef159099b88f640637d789c69011d0bc94705dacab85b81133e929d027d85210e8b8b03f8035164dbc14710
-  languageName: node
-  linkType: hard
-
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
@@ -2945,66 +1953,6 @@ __metadata:
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
   checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.10.1":
-  version: 1.22.12
-  resolution: "resolve@npm:1.22.12"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^2.0.0-next.6":
-  version: 2.0.0-next.6
-  resolution: "resolve@npm:2.0.0-next.6"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    node-exports-info: "npm:^1.6.0"
-    object-keys: "npm:^1.1.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/4e44cb84aa9a3c7c82d4a98e8111879671150496160a53ca6cdbed6101bf239f19105f8b8b84e40c0b76d46b0d9626813510b19a80e01f4ae18692e9d0b47749
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>":
-  version: 1.22.12
-  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^2.0.0-next.6#optional!builtin<compat/resolve>":
-  version: 2.0.0-next.6
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.6#optional!builtin<compat/resolve>::version=2.0.0-next.6&hash=c3c19d"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    node-exports-info: "npm:^1.6.0"
-    object-keys: "npm:^1.1.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/dca533e38820b0d8d636f269824cef3b7435802ab7401211c6f10af03be0e2f7e216047234e1623046c0a6791577079767e0c04f0d36e42c7f567b1bff7b0742
   languageName: node
   linkType: hard
 
@@ -3066,40 +2014,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-array-concat@npm:^1.1.3":
-  version: 1.1.4
-  resolution: "safe-array-concat@npm:1.1.4"
-  dependencies:
-    call-bind: "npm:^1.0.9"
-    call-bound: "npm:^1.0.4"
-    get-intrinsic: "npm:^1.3.0"
-    has-symbols: "npm:^1.1.0"
-    isarray: "npm:^2.0.5"
-  checksum: 10c0/95fb4904ab1d9360a666fe5ba6d88f1c4a3a39682739e4512cff809fc6b5722a94bd95189211015bfb45859a7ffbc3340ea303ae22721c91c59e8946d310975a
-  languageName: node
-  linkType: hard
-
-"safe-push-apply@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "safe-push-apply@npm:1.0.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    isarray: "npm:^2.0.5"
-  checksum: 10c0/831f1c9aae7436429e7862c7e46f847dfe490afac20d0ee61bae06108dbf5c745a0de3568ada30ccdd3eeb0864ca8331b2eef703abd69bfea0745b21fd320750
-  languageName: node
-  linkType: hard
-
-"safe-regex-test@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "safe-regex-test@npm:1.1.0"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    is-regex: "npm:^1.2.1"
-  checksum: 10c0/f2c25281bbe5d39cddbbce7f86fca5ea9b3ce3354ea6cd7c81c31b006a5a9fff4286acc5450a3b9122c56c33eba69c56b9131ad751457b2b4a585825e6a10665
-  languageName: node
-  linkType: hard
-
 "sass@npm:^1.99.0":
   version: 1.99.0
   resolution: "sass@npm:1.99.0"
@@ -3126,58 +2040,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.1.0, semver@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "semver@npm:6.3.1"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
-  languageName: node
-  linkType: hard
-
 "semver@npm:^7.3.5, semver@npm:^7.5.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
-  languageName: node
-  linkType: hard
-
-"set-function-length@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "set-function-length@npm:1.2.2"
-  dependencies:
-    define-data-property: "npm:^1.1.4"
-    es-errors: "npm:^1.3.0"
-    function-bind: "npm:^1.1.2"
-    get-intrinsic: "npm:^1.2.4"
-    gopd: "npm:^1.0.1"
-    has-property-descriptors: "npm:^1.0.2"
-  checksum: 10c0/82850e62f412a258b71e123d4ed3873fa9377c216809551192bb6769329340176f109c2eeae8c22a8d386c76739855f78e8716515c818bcaef384b51110f0f3c
-  languageName: node
-  linkType: hard
-
-"set-function-name@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "set-function-name@npm:2.0.2"
-  dependencies:
-    define-data-property: "npm:^1.1.4"
-    es-errors: "npm:^1.3.0"
-    functions-have-names: "npm:^1.2.3"
-    has-property-descriptors: "npm:^1.0.2"
-  checksum: 10c0/fce59f90696c450a8523e754abb305e2b8c73586452619c2bad5f7bf38c7b6b4651895c9db895679c5bef9554339cf3ef1c329b66ece3eda7255785fbe299316
-  languageName: node
-  linkType: hard
-
-"set-proto@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "set-proto@npm:1.0.0"
-  dependencies:
-    dunder-proto: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
   languageName: node
   linkType: hard
 
@@ -3194,54 +2062,6 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
-  languageName: node
-  linkType: hard
-
-"side-channel-list@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "side-channel-list@npm:1.0.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
-  languageName: node
-  linkType: hard
-
-"side-channel-map@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "side-channel-map@npm:1.0.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.5"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10c0/010584e6444dd8a20b85bc926d934424bd809e1a3af941cace229f7fdcb751aada0fb7164f60c2e22292b7fa3c0ff0bce237081fd4cdbc80de1dc68e95430672
-  languageName: node
-  linkType: hard
-
-"side-channel-weakmap@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "side-channel-weakmap@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.5"
-    object-inspect: "npm:^1.13.3"
-    side-channel-map: "npm:^1.0.1"
-  checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "side-channel@npm:1.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-    side-channel-list: "npm:^1.0.0"
-    side-channel-map: "npm:^1.0.1"
-    side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
   languageName: node
   linkType: hard
 
@@ -3273,61 +2093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stop-iteration-iterator@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "stop-iteration-iterator@npm:1.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    internal-slot: "npm:^1.1.0"
-  checksum: 10c0/de4e45706bb4c0354a4b1122a2b8cc45a639e86206807ce0baf390ee9218d3ef181923fa4d2b67443367c491aa255c5fbaa64bb74648e3c5b48299928af86c09
-  languageName: node
-  linkType: hard
-
-"string.prototype.trim@npm:^1.2.10":
-  version: 1.2.10
-  resolution: "string.prototype.trim@npm:1.2.10"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.2"
-    define-data-property: "npm:^1.1.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.5"
-    es-object-atoms: "npm:^1.0.0"
-    has-property-descriptors: "npm:^1.0.2"
-  checksum: 10c0/8a8854241c4b54a948e992eb7dd6b8b3a97185112deb0037a134f5ba57541d8248dd610c966311887b6c2fd1181a3877bffb14d873ce937a344535dabcc648f8
-  languageName: node
-  linkType: hard
-
-"string.prototype.trimend@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "string.prototype.trimend@npm:1.0.9"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.2"
-    define-properties: "npm:^1.2.1"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/59e1a70bf9414cb4c536a6e31bef5553c8ceb0cf44d8b4d0ed65c9653358d1c64dd0ec203b100df83d0413bbcde38b8c5d49e14bc4b86737d74adc593a0d35b6
-  languageName: node
-  linkType: hard
-
-"string.prototype.trimstart@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "string.prototype.trimstart@npm:1.0.8"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
-  languageName: node
-  linkType: hard
-
-"strip-bom@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-bom@npm:3.0.0"
-  checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
-  languageName: node
-  linkType: hard
-
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -3341,13 +2106,6 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
-  languageName: node
-  linkType: hard
-
-"supports-preserve-symlinks-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
-  checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
   languageName: node
   linkType: hard
 
@@ -3447,18 +2205,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.15.0":
-  version: 3.15.0
-  resolution: "tsconfig-paths@npm:3.15.0"
-  dependencies:
-    "@types/json5": "npm:^0.0.29"
-    json5: "npm:^1.0.2"
-    minimist: "npm:^1.2.6"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10c0/5b4f301a2b7a3766a986baf8fc0e177eb80bdba6e396792ff92dc23b5bca8bb279fc96517dcaaef63a3b49bebc6c4c833653ec58155780bc906bdbcf7dda0ef5
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -3472,71 +2218,6 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
-  languageName: node
-  linkType: hard
-
-"typed-array-buffer@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "typed-array-buffer@npm:1.0.3"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    is-typed-array: "npm:^1.1.14"
-  checksum: 10c0/1105071756eb248774bc71646bfe45b682efcad93b55532c6ffa4518969fb6241354e4aa62af679ae83899ec296d69ef88f1f3763657cdb3a4d29321f7b83079
-  languageName: node
-  linkType: hard
-
-"typed-array-byte-length@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "typed-array-byte-length@npm:1.0.3"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    for-each: "npm:^0.3.3"
-    gopd: "npm:^1.2.0"
-    has-proto: "npm:^1.2.0"
-    is-typed-array: "npm:^1.1.14"
-  checksum: 10c0/6ae083c6f0354f1fce18b90b243343b9982affd8d839c57bbd2c174a5d5dc71be9eb7019ffd12628a96a4815e7afa85d718d6f1e758615151d5f35df841ffb3e
-  languageName: node
-  linkType: hard
-
-"typed-array-byte-offset@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "typed-array-byte-offset@npm:1.0.4"
-  dependencies:
-    available-typed-arrays: "npm:^1.0.7"
-    call-bind: "npm:^1.0.8"
-    for-each: "npm:^0.3.3"
-    gopd: "npm:^1.2.0"
-    has-proto: "npm:^1.2.0"
-    is-typed-array: "npm:^1.1.15"
-    reflect.getprototypeof: "npm:^1.0.9"
-  checksum: 10c0/3d805b050c0c33b51719ee52de17c1cd8e6a571abdf0fffb110e45e8dd87a657e8b56eee94b776b13006d3d347a0c18a730b903cf05293ab6d92e99ff8f77e53
-  languageName: node
-  linkType: hard
-
-"typed-array-length@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "typed-array-length@npm:1.0.7"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    for-each: "npm:^0.3.3"
-    gopd: "npm:^1.0.1"
-    is-typed-array: "npm:^1.1.13"
-    possible-typed-array-names: "npm:^1.0.0"
-    reflect.getprototypeof: "npm:^1.0.6"
-  checksum: 10c0/e38f2ae3779584c138a2d8adfa8ecf749f494af3cd3cdafe4e688ce51418c7d2c5c88df1bd6be2bbea099c3f7cea58c02ca02ed438119e91f162a9de23f61295
-  languageName: node
-  linkType: hard
-
-"unbox-primitive@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "unbox-primitive@npm:1.1.0"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    has-bigints: "npm:^1.0.2"
-    has-symbols: "npm:^1.1.0"
-    which-boxed-primitive: "npm:^1.1.1"
-  checksum: 10c0/7dbd35ab02b0e05fe07136c72cb9355091242455473ec15057c11430129bab38b7b3624019b8778d02a881c13de44d63cd02d122ee782fb519e1de7775b5b982
   languageName: node
   linkType: hard
 
@@ -3722,67 +2403,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "which-boxed-primitive@npm:1.1.1"
-  dependencies:
-    is-bigint: "npm:^1.1.0"
-    is-boolean-object: "npm:^1.2.1"
-    is-number-object: "npm:^1.1.1"
-    is-string: "npm:^1.1.1"
-    is-symbol: "npm:^1.1.1"
-  checksum: 10c0/aceea8ede3b08dede7dce168f3883323f7c62272b49801716e8332ff750e7ae59a511ae088840bc6874f16c1b7fd296c05c949b0e5b357bfe3c431b98c417abe
-  languageName: node
-  linkType: hard
-
-"which-builtin-type@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "which-builtin-type@npm:1.2.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    function.prototype.name: "npm:^1.1.6"
-    has-tostringtag: "npm:^1.0.2"
-    is-async-function: "npm:^2.0.0"
-    is-date-object: "npm:^1.1.0"
-    is-finalizationregistry: "npm:^1.1.0"
-    is-generator-function: "npm:^1.0.10"
-    is-regex: "npm:^1.2.1"
-    is-weakref: "npm:^1.0.2"
-    isarray: "npm:^2.0.5"
-    which-boxed-primitive: "npm:^1.1.0"
-    which-collection: "npm:^1.0.2"
-    which-typed-array: "npm:^1.1.16"
-  checksum: 10c0/8dcf323c45e5c27887800df42fbe0431d0b66b1163849bb7d46b5a730ad6a96ee8bfe827d078303f825537844ebf20c02459de41239a0a9805e2fcb3cae0d471
-  languageName: node
-  linkType: hard
-
-"which-collection@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "which-collection@npm:1.0.2"
-  dependencies:
-    is-map: "npm:^2.0.3"
-    is-set: "npm:^2.0.3"
-    is-weakmap: "npm:^2.0.2"
-    is-weakset: "npm:^2.0.3"
-  checksum: 10c0/3345fde20964525a04cdf7c4a96821f85f0cc198f1b2ecb4576e08096746d129eb133571998fe121c77782ac8f21cbd67745a3d35ce100d26d4e684c142ea1f2
-  languageName: node
-  linkType: hard
-
-"which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
-  version: 1.1.20
-  resolution: "which-typed-array@npm:1.1.20"
-  dependencies:
-    available-typed-arrays: "npm:^1.0.7"
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    for-each: "npm:^0.3.5"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/16fcdada95c8afb821cd1117f0ab50b4d8551677ac08187f21d4e444530913c9ffd2dac634f0c1183345f96344b69280f40f9a8bc52164ef409e555567c2604b
-  languageName: node
-  linkType: hard
-
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -3828,15 +2448,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "words@workspace:."
   dependencies:
-    "@eslint/eslintrc": "npm:^3.3.5"
     "@eslint/js": "npm:^9.39.4"
     "@vitest/coverage-v8": "npm:^4.1.5"
     eslint: "npm:^9.39.4"
-    eslint-plugin-import: "npm:^2.32.0"
-    eslint-plugin-node: "npm:^11.1.0"
-    eslint-plugin-promise: "npm:^7.2.1"
+    eslint-config-prettier: "npm:^10.1.8"
     globals: "npm:^16.5.0"
     jsdom: "npm:^29.1.1"
+    prettier: "npm:^3.8.3"
     sass: "npm:^1.99.0"
     tippy.js: "npm:^6.3.7"
     vite: "npm:^8.0.10"


### PR DESCRIPTION
## Summary

- Installs `prettier` 3 and `eslint-config-prettier` 10
- Creates `.prettierrc` (no semi, single quotes, 2-space indent, trailing commas — matches `.editorconfig`)
- Creates `.prettierignore` (excludes `dist/`, `netlify/`, `.yarn/`, `albert.min.css`, `yarn.lock`)
- Removes `@eslint/eslintrc` + `FlatCompat` boilerplate from `eslint.config.mjs`; switches to `js.configs.recommended` directly
- Removes three unused ESLint plugins (`eslint-plugin-import`, `eslint-plugin-node`, `eslint-plugin-promise`)
- Strips all formatting rules from ESLint — only `no-console: warn` remains; `eslintConfigPrettier` added at end to silence any remaining conflicts
- Reformats all `src/`, `test/`, HTML, SCSS, config, and script files
- Updates `.vscode/settings.json` to use `esbenp.prettier-vscode` as default formatter with `formatOnSave: true`
- Adds `yarn format` / `yarn format:check` scripts
- Updates README and CLAUDE.md

## Follow-up (after PRs #57 and this one merge)

Update `.husky/pre-commit` to prepend `yarn format:check` so the full pre-commit sequence is:
```
yarn format:check && yarn lint && yarn test
```

## Test plan

- [ ] `yarn format:check` — passes clean
- [ ] `yarn lint` — passes clean
- [ ] `yarn test` — 51/51 green
- [ ] `yarn build` — clean output