### PR TITLE
chore: reset Prettier to defaults, reformat all files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install dependencies

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,1 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "all"
-}
+{}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,4 +103,4 @@ Cross-repo sync complete. No open TODOs or blockers.
 
 ### Code style
 
-Prettier handles all formatting (JS, HTML, CSS/SCSS) with settings in `.prettierrc`: no semicolons, single quotes, 2-space indent, trailing commas. ESLint (`eslint.config.mjs`) is scoped to code-quality rules only — `no-console` warn, `js.configs.recommended`. Formatting rules have been removed from ESLint to avoid conflicts. Run `yarn format` to reformat; `yarn format:check` for CI.
+Prettier handles all formatting (JS, HTML, CSS/SCSS) with `.prettierrc: {}` (all defaults). ESLint (`eslint.config.mjs`) is scoped to code-quality rules only — `no-console` warn, `js.configs.recommended`. Formatting rules have been removed from ESLint to avoid conflicts. Run `yarn format` to reformat; `yarn format:check` for CI.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
-import globals from 'globals'
-import js from '@eslint/js'
-import eslintConfigPrettier from 'eslint-config-prettier'
+import globals from "globals";
+import js from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
   js.configs.recommended,
@@ -11,11 +11,11 @@ export default [
         ...globals.node,
       },
       ecmaVersion: 12,
-      sourceType: 'module',
+      sourceType: "module",
     },
   },
   {
-    files: ['test/**/*.js'],
+    files: ["test/**/*.js"],
     languageOptions: {
       globals: {
         ...globals.jest,
@@ -24,8 +24,8 @@ export default [
   },
   {
     rules: {
-      'no-console': 'warn',
+      "no-console": "warn",
     },
   },
   eslintConfigPrettier,
-]
+];

--- a/scripts/copy-netlify.mjs
+++ b/scripts/copy-netlify.mjs
@@ -1,7 +1,7 @@
-import { cpSync, mkdirSync, readdirSync } from 'fs'
+import { cpSync, mkdirSync, readdirSync } from "fs";
 
-mkdirSync('netlify/words', { recursive: true })
-for (const entry of readdirSync('netlify')) {
-  if (entry === 'words') continue
-  cpSync(`netlify/${entry}`, `netlify/words/${entry}`, { recursive: true })
+mkdirSync("netlify/words", { recursive: true });
+for (const entry of readdirSync("netlify")) {
+  if (entry === "words") continue;
+  cpSync(`netlify/${entry}`, `netlify/words/${entry}`, { recursive: true });
 }

--- a/src/index.html
+++ b/src/index.html
@@ -12,9 +12,9 @@
     />
 
     <script>
-      ;(() =>
-        !window.location.pathname.endsWith('/') &&
-        window.location.replace(window.location.href + '/'))()
+      (() =>
+        !window.location.pathname.endsWith("/") &&
+        window.location.replace(window.location.href + "/"))();
     </script>
 
     <link

--- a/src/scripts/cleanup.js
+++ b/src/scripts/cleanup.js
@@ -1,5 +1,5 @@
 // cleanup old stored data
 export const cleanup = () => {
-  window.localStorage.removeItem('craigmcn-words-compress')
-  window.localStorage.removeItem('craigmcn-words-icons-only')
-}
+  window.localStorage.removeItem("craigmcn-words-compress");
+  window.localStorage.removeItem("craigmcn-words-icons-only");
+};

--- a/src/scripts/dragDrop.js
+++ b/src/scripts/dragDrop.js
@@ -1,182 +1,182 @@
-import { setComplete } from './game'
-import { $letters, updateLetter } from './letters'
-import { updateGrid } from './grid'
+import { setComplete } from "./game";
+import { $letters, updateLetter } from "./letters";
+import { updateGrid } from "./grid";
 
 /* Dragging and Dropping */
-let dragSource, dropTarget
+let dragSource, dropTarget;
 
 const getDragSource = (el) =>
-  el.classList.contains('words__cell') ? el : el.closest('ul')
-const getDropTarget = getDragSource
+  el.classList.contains("words__cell") ? el : el.closest("ul");
+const getDropTarget = getDragSource;
 const isDropTarget = (el) =>
-  el.classList.contains('words__cell') || !!el.closest('ul')
+  el.classList.contains("words__cell") || !!el.closest("ul");
 
 const handleDragStart = (e) => {
   // console.log('handleDragStart', e)
-  const el = e.target
+  const el = e.target;
   if (el.draggable) {
-    dragSource = getDragSource(el)
-    dragSource.dataset.transfer = el.dataset.value
+    dragSource = getDragSource(el);
+    dragSource.dataset.transfer = el.dataset.value;
   }
-  const touch = e.targetTouches
+  const touch = e.targetTouches;
   if (el.dataset) {
     if (touch) {
-      const touchLocation = touch[0]
-      el.dataset.pageX = touchLocation.pageX - window.scrollX
-      el.dataset.pageY = touchLocation.pageY - window.scrollY
+      const touchLocation = touch[0];
+      el.dataset.pageX = touchLocation.pageX - window.scrollX;
+      el.dataset.pageY = touchLocation.pageY - window.scrollY;
     } else {
-      el.dataset.pageX = e.x
-      el.dataset.pageY = e.y
+      el.dataset.pageX = e.x;
+      el.dataset.pageY = e.y;
     }
   }
-}
+};
 
 const handleDragEnd = (e) => {
   // console.log('handleDragEnd', e)
-  if (e.dataTransfer.dropEffect !== 'none' && dropTarget !== dragSource) {
-    handleDropEffect(e.target)
+  if (e.dataTransfer.dropEffect !== "none" && dropTarget !== dragSource) {
+    handleDropEffect(e.target);
   }
-  clearDragOver()
-}
+  clearDragOver();
+};
 
 const handleDropEffect = (el) => {
   // console.log('handleDropEffect', el)
-  dragSource && dragSource.removeAttribute('data-transfer')
-  if (el && el.classList.contains('letters__item')) {
-    el.classList.add('used')
-    el.draggable = false
-    setComplete($letters)
-    updateLetter(el.dataset.value, true)
-  } else if (el && el.classList.contains('words__cell')) {
-    el.innerText = ''
-    el.removeAttribute('data-value')
-    el.removeAttribute('draggable')
-    el.classList.remove('used')
-    removeDragging(el)
-    updateGrid('', el.dataset.row, el.dataset.col)
+  dragSource && dragSource.removeAttribute("data-transfer");
+  if (el && el.classList.contains("letters__item")) {
+    el.classList.add("used");
+    el.draggable = false;
+    setComplete($letters);
+    updateLetter(el.dataset.value, true);
+  } else if (el && el.classList.contains("words__cell")) {
+    el.innerText = "";
+    el.removeAttribute("data-value");
+    el.removeAttribute("draggable");
+    el.classList.remove("used");
+    removeDragging(el);
+    updateGrid("", el.dataset.row, el.dataset.col);
   }
-  el.removeAttribute('data-page-x')
-  el.removeAttribute('data-page-y')
-  dragSource = undefined
-}
+  el.removeAttribute("data-page-x");
+  el.removeAttribute("data-page-y");
+  dragSource = undefined;
+};
 
 const handleTouchMove = (e) => {
   // console.log('handleTouchMove', e)
-  e.preventDefault()
-  const el = e.target
-  const touchLocation = e.targetTouches[0]
-  el.dataset.pageX = touchLocation.pageX - window.scrollX
-  el.dataset.pageY = touchLocation.pageY - window.scrollY
+  e.preventDefault();
+  const el = e.target;
+  const touchLocation = e.targetTouches[0];
+  el.dataset.pageX = touchLocation.pageX - window.scrollX;
+  el.dataset.pageY = touchLocation.pageY - window.scrollY;
 
   const touchElement = document.elementFromPoint(
     el.dataset.pageX,
     el.dataset.pageY,
-  )
-  const dragoverElement = document.querySelector('.dragover')
-  touchElement && touchElement.classList.add('dragover')
+  );
+  const dragoverElement = document.querySelector(".dragover");
+  touchElement && touchElement.classList.add("dragover");
   if (dragoverElement && touchElement !== dragoverElement) {
-    dragoverElement.classList.remove('dragover')
+    dragoverElement.classList.remove("dragover");
   }
-}
+};
 
 const handleTouchEnd = (e) => {
   // console.log('handleTouchEnd', e)
-  const el = e.target
+  const el = e.target;
   const dropElement = document.elementFromPoint(
     el.dataset.pageX,
     el.dataset.pageY,
-  )
-  dropTarget = getDropTarget(dropElement)
+  );
+  dropTarget = getDropTarget(dropElement);
   if (dropElement && isDropTarget(dropElement) && dropTarget !== dragSource) {
-    doDrop(dropElement)
-    handleDropEffect(el)
+    doDrop(dropElement);
+    handleDropEffect(el);
   }
-  clearDragOver()
-}
+  clearDragOver();
+};
 
 const handleDragOver = (e) => {
   // console.log('handleDragOver', e)
-  e.preventDefault()
-  isDropTarget(e.target) && getDropTarget(e.target).classList.add('dragover')
-}
+  e.preventDefault();
+  isDropTarget(e.target) && getDropTarget(e.target).classList.add("dragover");
+};
 
 const handleDragLeave = (e) => {
   // console.log('handleDragLeave', e)
-  let el = e.target
-  if (!el.classList) el = el.parentElement
-  el.classList.remove('dragover')
-}
+  let el = e.target;
+  if (!el.classList) el = el.parentElement;
+  el.classList.remove("dragover");
+};
 
 const handleDrop = (e) => {
   // console.log('handleDrop', e)
-  e.preventDefault()
-  doDrop(e.target)
-  clearDragOver()
-}
+  e.preventDefault();
+  doDrop(e.target);
+  clearDragOver();
+};
 
 const doDrop = (el) => {
   if (dragSource) {
-    const data = dragSource.dataset.transfer
-    dropTarget = getDropTarget(el)
-    dropTarget.classList.remove('dragover')
+    const data = dragSource.dataset.transfer;
+    dropTarget = getDropTarget(el);
+    dropTarget.classList.remove("dragover");
     if (data !== undefined && dropTarget !== dragSource) {
-      if (el.classList.contains('words__cell')) {
+      if (el.classList.contains("words__cell")) {
         // dropped onto word grid
-        if (el.dataset.value) handleReturn(el.dataset.value)
-        el.classList.add('used')
-        el.dataset.value = data
-        el.draggable = true
-        el.innerText = data
-        initDragging(el)
-        updateGrid(data, el.dataset.row, el.dataset.col)
+        if (el.dataset.value) handleReturn(el.dataset.value);
+        el.classList.add("used");
+        el.dataset.value = data;
+        el.draggable = true;
+        el.innerText = data;
+        initDragging(el);
+        updateGrid(data, el.dataset.row, el.dataset.col);
       } else {
-        handleReturn(data)
+        handleReturn(data);
       }
     }
   }
-}
+};
 
 // dropped back onto letter list
 const handleReturn = (data) => {
   // console.log('handleReturn', data)
   const letterItem = $letters.querySelector(
     `.letters__item.used[data-value="${data}"]`,
-  )
+  );
   if (letterItem) {
-    letterItem.classList.remove('used')
-    letterItem.draggable = true
+    letterItem.classList.remove("used");
+    letterItem.draggable = true;
   }
-  setComplete($letters)
-  updateLetter(data, false)
-}
+  setComplete($letters);
+  updateLetter(data, false);
+};
 
 const clearDragOver = () => {
-  const dragOverElement = document.querySelector('.dragover')
-  dragOverElement && dragOverElement.classList.remove('dragover')
-}
+  const dragOverElement = document.querySelector(".dragover");
+  dragOverElement && dragOverElement.classList.remove("dragover");
+};
 
 export const initDragging = (el) => {
-  el.addEventListener('touchstart', handleDragStart, {
+  el.addEventListener("touchstart", handleDragStart, {
     passive: true,
-  })
-  el.addEventListener('dragstart', handleDragStart)
-  el.addEventListener('touchmove', handleTouchMove)
-  el.addEventListener('touchend', handleTouchEnd, {
+  });
+  el.addEventListener("dragstart", handleDragStart);
+  el.addEventListener("touchmove", handleTouchMove);
+  el.addEventListener("touchend", handleTouchEnd, {
     passive: true,
-  })
-  el.addEventListener('dragend', handleDragEnd)
-}
+  });
+  el.addEventListener("dragend", handleDragEnd);
+};
 
 const removeDragging = (el) => {
-  el.removeEventListener('touchstart', handleDragStart)
-  el.removeEventListener('dragstart', handleDragStart)
-  el.removeEventListener('touchmove', handleTouchMove)
-  el.removeEventListener('touchend', handleTouchEnd)
-  el.removeEventListener('dragend', handleDragEnd)
-}
+  el.removeEventListener("touchstart", handleDragStart);
+  el.removeEventListener("dragstart", handleDragStart);
+  el.removeEventListener("touchmove", handleTouchMove);
+  el.removeEventListener("touchend", handleTouchEnd);
+  el.removeEventListener("dragend", handleDragEnd);
+};
 
 export const initDropping = (el) => {
-  el.addEventListener('dragover', handleDragOver)
-  el.addEventListener('dragleave', handleDragLeave)
-  el.addEventListener('drop', handleDrop)
-}
+  el.addEventListener("dragover", handleDragOver);
+  el.addEventListener("dragleave", handleDragLeave);
+  el.addEventListener("drop", handleDrop);
+};

--- a/src/scripts/game.js
+++ b/src/scripts/game.js
@@ -1,43 +1,43 @@
-import { buildLetters } from './letters'
-import { buildGrid } from './grid'
-import { swapIcons, hideButtonText, hideHeaderFooter } from './toggle'
+import { buildLetters } from "./letters";
+import { buildGrid } from "./grid";
+import { swapIcons, hideButtonText, hideHeaderFooter } from "./toggle";
 
-export const STORAGEID = 'game'
+export const STORAGEID = "game";
 
 export const dice = [
-  ['D', 'E', 'N', 'O', 'S', 'W'],
-  ['A', 'E', 'F', 'J', 'R', 'Z'],
-  ['E', 'G', 'K', 'L', 'U', 'Y'],
-  ['D', 'I', 'K', 'O', 'P', 'W'],
-  ['A', 'A', 'C', 'E', 'J', 'P'],
-  ['B', 'F', 'I', 'O', 'R', 'X'],
-  ['A', 'E', 'E', 'F', 'H', 'M'],
-  ['A', 'A', 'C', 'I', 'O', 'T'],
-  ['A', 'H', 'M', 'O', 'R', 'S'],
-  ['A', 'B', 'I', 'L', 'T', 'Y'],
-  ['A', 'D', 'N', 'T', 'W', 'Y'],
-  ['A', 'D', 'E', 'I', 'L', 'O'],
-  ['E', 'G', 'I', 'N', 'T', 'V'],
-  ['D', 'K', 'N', 'O', 'T', 'U'],
-  ['E', 'F', 'H', 'I', 'T', 'Y'],
-  ['A', 'D', 'G', 'H', 'I', 'T'],
-  ['A', 'D', 'E', 'H', 'N', 'T'],
-  ['A', 'B', 'E', 'K', 'L', 'U'],
-  ['A', 'E', 'M', 'P', 'S', 'Y'],
-  ['E', 'H', 'I', 'N', 'P', 'S'],
-  ['A', 'C', 'E', 'L', 'R', 'S'],
-  ['B', 'F', 'O', 'R', 'U', ' '],
-  ['H', 'I', 'L', 'O', 'S', 'X'],
-  ['F', 'L', 'O', 'R', 'Z', ' '],
-  ['A', 'C', 'D', 'E', 'N', 'P'],
-  ['U', 'U', 'U', 'U', 'U', 'U'],
-  ['A', 'C', 'G', 'R', 'S', 'T'],
-  ['G', 'I', 'L', 'M', 'R', 'W'],
-  ['A', 'B', 'L', 'M', 'O', 'Q'],
-  ['A', 'E', 'G', 'M', 'R', 'S'],
-  ['A', 'D', 'E', 'O', 'T', 'V'],
-  ['A', 'D', 'E', 'J', 'P', 'V'],
-]
+  ["D", "E", "N", "O", "S", "W"],
+  ["A", "E", "F", "J", "R", "Z"],
+  ["E", "G", "K", "L", "U", "Y"],
+  ["D", "I", "K", "O", "P", "W"],
+  ["A", "A", "C", "E", "J", "P"],
+  ["B", "F", "I", "O", "R", "X"],
+  ["A", "E", "E", "F", "H", "M"],
+  ["A", "A", "C", "I", "O", "T"],
+  ["A", "H", "M", "O", "R", "S"],
+  ["A", "B", "I", "L", "T", "Y"],
+  ["A", "D", "N", "T", "W", "Y"],
+  ["A", "D", "E", "I", "L", "O"],
+  ["E", "G", "I", "N", "T", "V"],
+  ["D", "K", "N", "O", "T", "U"],
+  ["E", "F", "H", "I", "T", "Y"],
+  ["A", "D", "G", "H", "I", "T"],
+  ["A", "D", "E", "H", "N", "T"],
+  ["A", "B", "E", "K", "L", "U"],
+  ["A", "E", "M", "P", "S", "Y"],
+  ["E", "H", "I", "N", "P", "S"],
+  ["A", "C", "E", "L", "R", "S"],
+  ["B", "F", "O", "R", "U", " "],
+  ["H", "I", "L", "O", "S", "X"],
+  ["F", "L", "O", "R", "Z", " "],
+  ["A", "C", "D", "E", "N", "P"],
+  ["U", "U", "U", "U", "U", "U"],
+  ["A", "C", "G", "R", "S", "T"],
+  ["G", "I", "L", "M", "R", "W"],
+  ["A", "B", "L", "M", "O", "Q"],
+  ["A", "E", "G", "M", "R", "S"],
+  ["A", "D", "E", "O", "T", "V"],
+  ["A", "D", "E", "J", "P", "V"],
+];
 
 export const defaultGame = {
   letters: [],
@@ -46,53 +46,53 @@ export const defaultGame = {
     width: 10,
     rows: [],
   },
-}
+};
 
 // Get game object from storage
 export const getGame = () => {
-  const game = window.localStorage.getItem(STORAGEID)
-  if (game) return JSON.parse(game)
-  return defaultGame
-}
+  const game = window.localStorage.getItem(STORAGEID);
+  if (game) return JSON.parse(game);
+  return defaultGame;
+};
 
 // Set game object in storage
 export const setGame = (game) => {
-  window.localStorage.setItem(STORAGEID, JSON.stringify(game))
-  return game
-}
+  window.localStorage.setItem(STORAGEID, JSON.stringify(game));
+  return game;
+};
 
 export const setComplete = ($letters) => {
-  $letters.classList.remove('complete')
-  if (!document.querySelectorAll('.letters__item:not(.used)').length) {
-    $letters.classList.add('complete')
-    return true
+  $letters.classList.remove("complete");
+  if (!document.querySelectorAll(".letters__item:not(.used)").length) {
+    $letters.classList.add("complete");
+    return true;
   }
-  return false
-}
+  return false;
+};
 
 export const initialize = () => {
   // handle localStorage
-  const compress = window.localStorage.getItem('compress')
-  const iconsOnly = window.localStorage.getItem('iconsOnly')
+  const compress = window.localStorage.getItem("compress");
+  const iconsOnly = window.localStorage.getItem("iconsOnly");
   if (compress) {
-    hideHeaderFooter()
-    swapIcons(document.getElementById('toggleHeaderFooter'))
+    hideHeaderFooter();
+    swapIcons(document.getElementById("toggleHeaderFooter"));
   }
   if (iconsOnly) {
-    hideButtonText()
-    swapIcons(document.getElementById('toggleButtonText'))
+    hideButtonText();
+    swapIcons(document.getElementById("toggleButtonText"));
   }
 
-  buildLetters()
-  buildGrid({})
-}
+  buildLetters();
+  buildGrid({});
+};
 
 export const roll = () => {
-  setGame(defaultGame)
-  buildLetters(false)
+  setGame(defaultGame);
+  buildLetters(false);
   buildGrid({
     height: defaultGame.grid.height,
     width: defaultGame.grid.width,
     stored: false,
-  })
-}
+  });
+};

--- a/src/scripts/grid.js
+++ b/src/scripts/grid.js
@@ -1,159 +1,159 @@
-import { getGame, setGame } from './game'
-import { resetLetters } from './letters'
-import { initDragging, initDropping } from './dragDrop'
+import { getGame, setGame } from "./game";
+import { resetLetters } from "./letters";
+import { initDragging, initDropping } from "./dragDrop";
 
-const $words = document.getElementById('words__grid').querySelector('tbody')
+const $words = document.getElementById("words__grid").querySelector("tbody");
 
 // Get and set grid height from game object
 export const getHeight = () => {
-  const game = getGame()
+  const game = getGame();
   const {
     grid: { height },
-  } = game
-  return height
-}
+  } = game;
+  return height;
+};
 
 export const setHeight = (height) => {
-  const game = getGame()
+  const game = getGame();
   setGame({
     ...game,
     grid: {
       ...game.grid,
       height,
     },
-  })
-}
+  });
+};
 
 // Get and set grid width from game object
 export const getWidth = () => {
-  const game = getGame()
+  const game = getGame();
   const {
     grid: { width },
-  } = game
-  return width
-}
+  } = game;
+  return width;
+};
 
 export const setWidth = (width) => {
-  const game = getGame()
+  const game = getGame();
   setGame({
     ...game,
     grid: {
       ...game.grid,
       width,
     },
-  })
-}
+  });
+};
 
 /* Create and update grid */
 export const buildGrid = (props) => {
-  const { height = getHeight(), width = getWidth(), stored = true } = props
-  const game = getGame()
-  $words.innerHTML = ''
+  const { height = getHeight(), width = getWidth(), stored = true } = props;
+  const game = getGame();
+  $words.innerHTML = "";
   for (let r = 0; r < height; r++) {
-    if (!game.grid.rows[r]) game.grid.rows[r] = Array(game.grid.width).fill('')
-    setGame(game)
-    $words.appendChild(createGridRow(width, r, stored))
+    if (!game.grid.rows[r]) game.grid.rows[r] = Array(game.grid.width).fill("");
+    setGame(game);
+    $words.appendChild(createGridRow(width, r, stored));
   }
-}
+};
 
 export const resetGrid = () => {
-  const game = getGame()
+  const game = getGame();
   game.grid.rows = Array(game.grid.height)
     .fill()
-    .map(() => Array(game.grid.width).fill(''))
-  setGame(game)
-  resetLetters()
-  buildGrid({})
-}
+    .map(() => Array(game.grid.width).fill(""));
+  setGame(game);
+  resetLetters();
+  buildGrid({});
+};
 
 export const updateGrid = (letter, row, column) => {
-  const game = getGame()
-  game.grid.rows[row][column] = letter
-  setGame(game)
-}
+  const game = getGame();
+  game.grid.rows[row][column] = letter;
+  setGame(game);
+};
 
 const indexGrid = () => {
-  ;[...$words.querySelectorAll('tr')].forEach((tr, r) => {
-    ;[...tr.querySelectorAll('td')].forEach((td, c) => {
-      td.dataset.row = r
-      td.dataset.col = c
-    })
-  })
-}
+  [...$words.querySelectorAll("tr")].forEach((tr, r) => {
+    [...tr.querySelectorAll("td")].forEach((td, c) => {
+      td.dataset.row = r;
+      td.dataset.col = c;
+    });
+  });
+};
 
 export const createGridCell = (r, c, stored = true) => {
   const {
     grid: { rows },
-  } = getGame()
-  const cell = document.createElement('td')
-  cell.className = 'words__cell'
-  cell.dataset.row = r
-  cell.dataset.col = c
+  } = getGame();
+  const cell = document.createElement("td");
+  cell.className = "words__cell";
+  cell.dataset.row = r;
+  cell.dataset.col = c;
   if (stored && rows[r][c]) {
-    cell.dataset.value = rows[r][c]
-    cell.innerText = rows[r][c]
-    cell.classList.add('used')
-    cell.draggable = true
-    initDragging(cell)
+    cell.dataset.value = rows[r][c];
+    cell.innerText = rows[r][c];
+    cell.classList.add("used");
+    cell.draggable = true;
+    initDragging(cell);
   }
-  initDropping(cell)
-  return cell
-}
+  initDropping(cell);
+  return cell;
+};
 
 export const createGridRow = (width, r, stored = true) => {
-  const row = document.createElement('tr')
+  const row = document.createElement("tr");
   for (let c = 0; c < width; c++) {
-    row.appendChild(createGridCell(r, c, stored))
+    row.appendChild(createGridCell(r, c, stored));
   }
-  return row
-}
+  return row;
+};
 
-const addRow = (direction = 'top') => {
-  const game = getGame()
-  if (direction === 'top') {
+const addRow = (direction = "top") => {
+  const game = getGame();
+  if (direction === "top") {
     $words.insertBefore(
       createGridRow(game.grid.width, 0, false),
       $words.firstChild,
       false,
-    )
-    game.grid.rows.unshift(Array(game.grid.width).fill(''))
+    );
+    game.grid.rows.unshift(Array(game.grid.width).fill(""));
   } else {
-    $words.appendChild(createGridRow(game.grid.width, game.grid.height, false))
-    game.grid.rows.push(Array(game.grid.width).fill(''))
+    $words.appendChild(createGridRow(game.grid.width, game.grid.height, false));
+    game.grid.rows.push(Array(game.grid.width).fill(""));
   }
-  game.grid.height++
-  setGame(game)
-  indexGrid()
-}
+  game.grid.height++;
+  setGame(game);
+  indexGrid();
+};
 
-const addColumn = (direction = 'left') => {
-  const game = getGame()
-  ;[...$words.querySelectorAll('tr')].forEach((tr, r) => {
-    if (direction === 'left') {
-      tr.insertBefore(createGridCell(r, 0, false), tr.firstChild)
-      game.grid.rows[r].unshift('')
+const addColumn = (direction = "left") => {
+  const game = getGame();
+  [...$words.querySelectorAll("tr")].forEach((tr, r) => {
+    if (direction === "left") {
+      tr.insertBefore(createGridCell(r, 0, false), tr.firstChild);
+      game.grid.rows[r].unshift("");
     } else {
-      tr.appendChild(createGridCell(r, game.grid.width, false))
-      game.grid.rows[r].push('')
+      tr.appendChild(createGridCell(r, game.grid.width, false));
+      game.grid.rows[r].push("");
     }
-  })
-  game.grid.width++
-  setGame(game)
-  indexGrid()
-}
+  });
+  game.grid.width++;
+  setGame(game);
+  indexGrid();
+};
 
 export const addRowTop = () => {
-  addRow('top')
-}
+  addRow("top");
+};
 
 export const addRowBottom = () => {
-  addRow('bottom')
-}
+  addRow("bottom");
+};
 
 export const addColumnLeft = () => {
-  addColumn('left')
-}
+  addColumn("left");
+};
 
 export const addColumnRight = () => {
-  addColumn('right')
-}
+  addColumn("right");
+};

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,44 +1,44 @@
-import 'tippy.js/dist/tippy.css'
-import { cleanup } from './cleanup'
-import registerServiceWorker from './serviceWorker'
-import { initialize, roll } from './game'
+import "tippy.js/dist/tippy.css";
+import { cleanup } from "./cleanup";
+import registerServiceWorker from "./serviceWorker";
+import { initialize, roll } from "./game";
 import {
   addRowTop,
   addRowBottom,
   addColumnLeft,
   addColumnRight,
   resetGrid,
-} from './grid'
-import { toggleButtonText, toggleHeaderFooter } from './toggle'
-import { handleKeyboard } from './keyboard'
-import tippy from 'tippy.js'
+} from "./grid";
+import { toggleButtonText, toggleHeaderFooter } from "./toggle";
+import { handleKeyboard } from "./keyboard";
+import tippy from "tippy.js";
 
-cleanup()
-registerServiceWorker()
+cleanup();
+registerServiceWorker();
 
 // handle controls
-document.getElementById('roll').addEventListener('click', roll)
-document.getElementById('reset').addEventListener('click', resetGrid)
-document.getElementById('addRowTop').addEventListener('click', addRowTop)
-document.getElementById('addRowBottom').addEventListener('click', addRowBottom)
+document.getElementById("roll").addEventListener("click", roll);
+document.getElementById("reset").addEventListener("click", resetGrid);
+document.getElementById("addRowTop").addEventListener("click", addRowTop);
+document.getElementById("addRowBottom").addEventListener("click", addRowBottom);
 document
-  .getElementById('addColumnLeft')
-  .addEventListener('click', addColumnLeft)
+  .getElementById("addColumnLeft")
+  .addEventListener("click", addColumnLeft);
 document
-  .getElementById('addColumnRight')
-  .addEventListener('click', addColumnRight)
-document.addEventListener('keyup', handleKeyboard, false)
+  .getElementById("addColumnRight")
+  .addEventListener("click", addColumnRight);
+document.addEventListener("keyup", handleKeyboard, false);
 document
-  .getElementById('toggleHeaderFooter')
-  .addEventListener('click', toggleHeaderFooter)
+  .getElementById("toggleHeaderFooter")
+  .addEventListener("click", toggleHeaderFooter);
 document
-  .getElementById('toggleButtonText')
-  .addEventListener('click', toggleButtonText)
+  .getElementById("toggleButtonText")
+  .addEventListener("click", toggleButtonText);
 
 // initialize game board
-initialize()
+initialize();
 
 // initialize tooltips
-tippy('[data-tippy-content]', {
-  placement: 'right',
-})
+tippy("[data-tippy-content]", {
+  placement: "right",
+});

--- a/src/scripts/keyboard.js
+++ b/src/scripts/keyboard.js
@@ -1,43 +1,43 @@
-import { roll } from './game'
+import { roll } from "./game";
 import {
   addRowTop,
   addRowBottom,
   addColumnLeft,
   addColumnRight,
   resetGrid,
-} from './grid'
-import { toggleButtonText, toggleHeaderFooter } from './toggle'
+} from "./grid";
+import { toggleButtonText, toggleHeaderFooter } from "./toggle";
 
 export const handleKeyboard = (e) => {
   if (e.ctrlKey) {
-    e.preventDefault()
+    e.preventDefault();
 
     switch (e.keyCode) {
       case 13: // Enter
-        roll()
-        break
+        roll();
+        break;
       case 36: // Home
-        resetGrid()
-        break
+        resetGrid();
+        break;
       case 37: // Arrow left
-        addColumnLeft()
-        break
+        addColumnLeft();
+        break;
       case 38: // Arrow up
-        addRowTop()
-        break
+        addRowTop();
+        break;
       case 39: // Arrow right
-        addColumnRight()
-        break
+        addColumnRight();
+        break;
       case 40: // Arrow down
-        addRowBottom()
-        break
+        addRowBottom();
+        break;
       case 46: // Delete
-        toggleHeaderFooter()
-        break
+        toggleHeaderFooter();
+        break;
       case 32: // Space
-        toggleButtonText()
-        break
+        toggleButtonText();
+        break;
       default:
     }
   }
-}
+};

--- a/src/scripts/letters.js
+++ b/src/scripts/letters.js
@@ -1,72 +1,72 @@
-import { dice, getGame, setGame, setComplete } from './game'
-import { initDragging, initDropping } from './dragDrop'
+import { dice, getGame, setGame, setComplete } from "./game";
+import { initDragging, initDropping } from "./dragDrop";
 
-export const $letters = document.getElementById('letters__list')
+export const $letters = document.getElementById("letters__list");
 
 const getLetters = (stored = true) => {
-  const game = getGame()
-  if (stored && game.letters.length) return game.letters
+  const game = getGame();
+  if (stored && game.letters.length) return game.letters;
 
-  const letters = []
+  const letters = [];
   dice.forEach((d) => {
     letters.push({
       letter: d[Math.floor(Math.random() * d.length)],
       used: false,
-    })
-  })
+    });
+  });
   letters.sort((a, b) =>
     a.letter === b.letter ? 0 : a.letter > b.letter ? 1 : -1,
-  )
+  );
   setGame({
     ...game,
     letters,
-  })
-  return letters
-}
+  });
+  return letters;
+};
 
 export const buildLetters = (stored = true) => {
-  $letters.innerHTML = ''
+  $letters.innerHTML = "";
   getLetters(stored).forEach((l) => {
-    const letter = document.createElement('li')
-    letter.className = 'letters__item'
-    letter.dataset.value = l.letter
-    letter.innerText = l.letter
-    letter.draggable = !l.used
-    if (l.used) letter.classList.add('used')
-    initDragging(letter)
-    $letters.appendChild(letter)
-  })
-  initDropping(document.getElementById('letters'))
-  setComplete($letters)
-}
+    const letter = document.createElement("li");
+    letter.className = "letters__item";
+    letter.dataset.value = l.letter;
+    letter.innerText = l.letter;
+    letter.draggable = !l.used;
+    if (l.used) letter.classList.add("used");
+    initDragging(letter);
+    $letters.appendChild(letter);
+  });
+  initDropping(document.getElementById("letters"));
+  setComplete($letters);
+};
 
 export const resetLetters = () => {
-  const game = getGame()
-  const letters = game.letters
-  ;[...document.querySelectorAll('.letters__item')].forEach((el) => {
-    el.classList.remove('used')
-    el.draggable = true
-  })
-  letters.forEach((l) => (l.used = false))
-  setComplete($letters)
+  const game = getGame();
+  const letters = game.letters;
+  [...document.querySelectorAll(".letters__item")].forEach((el) => {
+    el.classList.remove("used");
+    el.draggable = true;
+  });
+  letters.forEach((l) => (l.used = false));
+  setComplete($letters);
   setGame({
     ...game,
     letters,
-  })
-}
+  });
+};
 
 export const updateLetter = (letter, used) => {
-  const game = getGame()
-  const letters = game.letters
-  const l = letters.length
+  const game = getGame();
+  const letters = game.letters;
+  const l = letters.length;
   for (let i = 0; i < l; i++) {
     if (letters[i].letter === letter && letters[i].used === !used) {
-      letters[i].used = used
-      break
+      letters[i].used = used;
+      break;
     }
   }
   setGame({
     ...game,
     letters,
-  })
-}
+  });
+};

--- a/src/scripts/serviceWorker.js
+++ b/src/scripts/serviceWorker.js
@@ -1,35 +1,35 @@
-import { STORAGEID } from './game'
+import { STORAGEID } from "./game";
 
 const registerServiceWorker = () => {
   // https://deanhume.com/displaying-a-new-version-available-progressive-web-app/
-  let newWorker
-  document.getElementById('reload').addEventListener('click', (e) => {
-    e.preventDefault()
+  let newWorker;
+  document.getElementById("reload").addEventListener("click", (e) => {
+    e.preventDefault();
     newWorker.postMessage({
-      action: 'skipWaiting',
-    })
-    window.sessionStorage.removeItem(STORAGEID)
-    window.localStorage.removeItem(STORAGEID)
-    window.location.reload()
-  })
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('sw.js').then((reg) => {
-      reg.addEventListener('updatefound', () => {
-        newWorker = reg.installing
-        newWorker.addEventListener('statechange', () => {
+      action: "skipWaiting",
+    });
+    window.sessionStorage.removeItem(STORAGEID);
+    window.localStorage.removeItem(STORAGEID);
+    window.location.reload();
+  });
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("sw.js").then((reg) => {
+      reg.addEventListener("updatefound", () => {
+        newWorker = reg.installing;
+        newWorker.addEventListener("statechange", () => {
           switch (newWorker.state) {
-            case 'installed':
+            case "installed":
               if (navigator.serviceWorker.controller) {
                 document
-                  .getElementById('notification')
-                  .removeAttribute('hidden')
+                  .getElementById("notification")
+                  .removeAttribute("hidden");
               }
-              break
+              break;
           }
-        })
-      })
-    })
+        });
+      });
+    });
   }
-}
+};
 
-export default registerServiceWorker
+export default registerServiceWorker;

--- a/src/scripts/toggle.js
+++ b/src/scripts/toggle.js
@@ -1,55 +1,55 @@
 /* Toggle actions */
-const header = document.getElementById('header')
-const footer = document.getElementById('footer')
-const buttonText = [...document.querySelectorAll('span.js-canHide')]
+const header = document.getElementById("header");
+const footer = document.getElementById("footer");
+const buttonText = [...document.querySelectorAll("span.js-canHide")];
 
 const showHeaderFooter = () => {
-  window.localStorage.removeItem('compress')
-  header.classList.remove('visually-hidden')
-  footer.classList.remove('visually-hidden')
-}
+  window.localStorage.removeItem("compress");
+  header.classList.remove("visually-hidden");
+  footer.classList.remove("visually-hidden");
+};
 
 export const hideHeaderFooter = () => {
-  window.localStorage.setItem('compress', 'true')
-  header.classList.add('visually-hidden')
-  footer.classList.add('visually-hidden')
-}
+  window.localStorage.setItem("compress", "true");
+  header.classList.add("visually-hidden");
+  footer.classList.add("visually-hidden");
+};
 
 export const toggleHeaderFooter = () => {
-  if (header.classList.contains('visually-hidden')) {
-    showHeaderFooter()
+  if (header.classList.contains("visually-hidden")) {
+    showHeaderFooter();
   } else {
-    hideHeaderFooter()
+    hideHeaderFooter();
   }
-  swapIcons(document.getElementById('toggleHeaderFooter'))
-}
+  swapIcons(document.getElementById("toggleHeaderFooter"));
+};
 
 const showButtonText = () => {
-  window.localStorage.removeItem('iconsOnly')
-  buttonText.forEach((b) => b.classList.remove('visually-hidden'))
-}
+  window.localStorage.removeItem("iconsOnly");
+  buttonText.forEach((b) => b.classList.remove("visually-hidden"));
+};
 
 export const hideButtonText = () => {
-  window.localStorage.setItem('iconsOnly', 'true')
-  buttonText.forEach((b) => b.classList.add('visually-hidden'))
-}
+  window.localStorage.setItem("iconsOnly", "true");
+  buttonText.forEach((b) => b.classList.add("visually-hidden"));
+};
 
 export const toggleButtonText = () => {
-  if (buttonText[0].classList.contains('visually-hidden')) {
-    showButtonText()
+  if (buttonText[0].classList.contains("visually-hidden")) {
+    showButtonText();
   } else {
-    hideButtonText()
+    hideButtonText();
   }
-  swapIcons(document.getElementById('toggleButtonText'))
-}
+  swapIcons(document.getElementById("toggleButtonText"));
+};
 
 // Swap icons
 export const swapIcons = (el) => {
-  ;[...el.querySelectorAll('svg')].forEach((s) => {
-    if (s.hasAttribute('hidden')) {
-      s.removeAttribute('hidden')
+  [...el.querySelectorAll("svg")].forEach((s) => {
+    if (s.hasAttribute("hidden")) {
+      s.removeAttribute("hidden");
     } else {
-      s.setAttribute('hidden', true)
+      s.setAttribute("hidden", true);
     }
-  })
-}
+  });
+};

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,5 +1,5 @@
-@use 'sass:color';
-@use 'sass:math';
+@use "sass:color";
+@use "sass:math";
 
 /* Variables */
 // Colours
@@ -93,7 +93,7 @@ footer {
   min-width: 2.5rem;
 
   &:empty::after {
-    content: '\00a0';
+    content: "\00a0";
   }
 
   @media (min-width: 992px) {
@@ -119,7 +119,7 @@ footer {
   border: 1px dashed $grey-500;
 
   &:empty::after {
-    content: '\00a0';
+    content: "\00a0";
   }
 
   &.used {
@@ -145,11 +145,11 @@ footer {
   width: 1.25em;
 }
 
-[draggable='true'] {
+[draggable="true"] {
   cursor: move;
 }
 
-[draggable='false'] {
+[draggable="false"] {
   cursor: not-allowed;
 }
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -14,80 +14,80 @@
 // Names of the two caches used in this version of the service worker.
 // Change to v2, etc. when you update any of the local resources, which will
 // in turn trigger the install event again.
-const PRECACHE = 'precache-{buildtime}'
-const RUNTIME = 'runtime'
+const PRECACHE = "precache-{buildtime}";
+const RUNTIME = "runtime";
 
 // A list of local resources we always want to be cached.
 const PRECACHE_URLS = [
-  './',
-  './?source=pwa',
-  'index.html',
-  './css/index.css',
-  './js/index.js',
-]
+  "./",
+  "./?source=pwa",
+  "index.html",
+  "./css/index.css",
+  "./js/index.js",
+];
 
 // The install handler takes care of pre-caching the resources we always need.
-self.addEventListener('install', (event) => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(PRECACHE)
       .then((cache) => cache.addAll(PRECACHE_URLS))
       .then(self.skipWaiting()),
-  )
-})
+  );
+});
 
 // The activate handler takes care of cleaning up old caches.
-self.addEventListener('activate', (event) => {
-  const currentCaches = [PRECACHE, RUNTIME]
+self.addEventListener("activate", (event) => {
+  const currentCaches = [PRECACHE, RUNTIME];
   event.waitUntil(
     caches
       .keys()
       .then((cacheNames) => {
         return cacheNames.filter(
           (cacheName) => !currentCaches.includes(cacheName),
-        )
+        );
       })
       .then((cachesToDelete) => {
         return Promise.all(
           cachesToDelete.map((cacheToDelete) => {
-            return caches.delete(cacheToDelete)
+            return caches.delete(cacheToDelete);
           }),
-        )
+        );
       })
       .then(() => self.clients.claim()),
-  )
-})
+  );
+});
 
-self.addEventListener('message', (event) => {
-  if (event.data.action === 'skipWaiting') {
-    self.skipWaiting()
+self.addEventListener("message", (event) => {
+  if (event.data.action === "skipWaiting") {
+    self.skipWaiting();
   }
-})
+});
 
 // The fetch handler serves responses for same-origin resources from a cache.
 // If no response is found, it populates the runtime cache with the response
 // from the network before returning it to the page.
-self.addEventListener('fetch', (event) => {
+self.addEventListener("fetch", (event) => {
   // Skip cross-origin requests, like those for Google Analytics, and POSTs.
   if (
     event.request.url.startsWith(self.location.origin) &&
-    event.request.method !== 'POST'
+    event.request.method !== "POST"
   ) {
     event.respondWith(
       caches.match(event.request).then((cachedResponse) => {
         if (cachedResponse) {
-          return cachedResponse
+          return cachedResponse;
         }
 
         return caches.open(RUNTIME).then((cache) => {
           return fetch(event.request).then((response) => {
             // Put a copy of the response in the runtime cache.
             return cache.put(event.request, response.clone()).then(() => {
-              return response
-            })
-          })
-        })
+              return response;
+            });
+          });
+        });
       }),
-    )
+    );
   }
-})
+});

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -1,27 +1,27 @@
-import { cleanup } from '../src/scripts/cleanup'
+import { cleanup } from "../src/scripts/cleanup";
 
 beforeEach(() => {
-  localStorage.clear()
-})
+  localStorage.clear();
+});
 
-describe('cleanup', () => {
-  it('removes legacy compress key', () => {
-    localStorage.setItem('craigmcn-words-compress', 'true')
-    cleanup()
-    expect(localStorage.getItem('craigmcn-words-compress')).toBeNull()
-  })
+describe("cleanup", () => {
+  it("removes legacy compress key", () => {
+    localStorage.setItem("craigmcn-words-compress", "true");
+    cleanup();
+    expect(localStorage.getItem("craigmcn-words-compress")).toBeNull();
+  });
 
-  it('removes legacy icons-only key', () => {
-    localStorage.setItem('craigmcn-words-icons-only', 'true')
-    cleanup()
-    expect(localStorage.getItem('craigmcn-words-icons-only')).toBeNull()
-  })
+  it("removes legacy icons-only key", () => {
+    localStorage.setItem("craigmcn-words-icons-only", "true");
+    cleanup();
+    expect(localStorage.getItem("craigmcn-words-icons-only")).toBeNull();
+  });
 
-  it('does not remove unrelated localStorage keys', () => {
-    localStorage.setItem('compress', 'true')
-    localStorage.setItem('game', '{}')
-    cleanup()
-    expect(localStorage.getItem('compress')).toBe('true')
-    expect(localStorage.getItem('game')).toBe('{}')
-  })
-})
+  it("does not remove unrelated localStorage keys", () => {
+    localStorage.setItem("compress", "true");
+    localStorage.setItem("game", "{}");
+    cleanup();
+    expect(localStorage.getItem("compress")).toBe("true");
+    expect(localStorage.getItem("game")).toBe("{}");
+  });
+});

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -5,99 +5,99 @@ import {
   getGame,
   setGame,
   setComplete,
-} from '../src/scripts/game'
+} from "../src/scripts/game";
 
 beforeEach(() => {
-  localStorage.clear()
-})
+  localStorage.clear();
+});
 
-describe('dice', () => {
-  it('has 32 entries', () => {
-    expect(dice).toHaveLength(32)
-  })
+describe("dice", () => {
+  it("has 32 entries", () => {
+    expect(dice).toHaveLength(32);
+  });
 
-  it('each die has 6 faces', () => {
-    dice.forEach((d) => expect(d).toHaveLength(6))
-  })
+  it("each die has 6 faces", () => {
+    dice.forEach((d) => expect(d).toHaveLength(6));
+  });
 
-  it('all faces are single characters', () => {
-    dice.forEach((d) => d.forEach((face) => expect(face).toHaveLength(1)))
-  })
-})
+  it("all faces are single characters", () => {
+    dice.forEach((d) => d.forEach((face) => expect(face).toHaveLength(1)));
+  });
+});
 
-describe('defaultGame', () => {
-  it('has an empty letters array', () => {
-    expect(defaultGame.letters).toEqual([])
-  })
+describe("defaultGame", () => {
+  it("has an empty letters array", () => {
+    expect(defaultGame.letters).toEqual([]);
+  });
 
-  it('has a 10x10 grid', () => {
-    expect(defaultGame.grid.height).toBe(10)
-    expect(defaultGame.grid.width).toBe(10)
-    expect(defaultGame.grid.rows).toEqual([])
-  })
-})
+  it("has a 10x10 grid", () => {
+    expect(defaultGame.grid.height).toBe(10);
+    expect(defaultGame.grid.width).toBe(10);
+    expect(defaultGame.grid.rows).toEqual([]);
+  });
+});
 
-describe('getGame', () => {
-  it('returns defaultGame when localStorage is empty', () => {
-    expect(getGame()).toEqual(defaultGame)
-  })
+describe("getGame", () => {
+  it("returns defaultGame when localStorage is empty", () => {
+    expect(getGame()).toEqual(defaultGame);
+  });
 
-  it('returns parsed game from localStorage', () => {
+  it("returns parsed game from localStorage", () => {
     const state = {
-      letters: [{ letter: 'A', used: false }],
+      letters: [{ letter: "A", used: false }],
       grid: { height: 5, width: 5, rows: [] },
-    }
-    localStorage.setItem(STORAGEID, JSON.stringify(state))
-    expect(getGame()).toEqual(state)
-  })
-})
+    };
+    localStorage.setItem(STORAGEID, JSON.stringify(state));
+    expect(getGame()).toEqual(state);
+  });
+});
 
-describe('setGame', () => {
-  it('persists game state to localStorage', () => {
-    const state = { letters: [], grid: { height: 3, width: 3, rows: [] } }
-    setGame(state)
-    expect(JSON.parse(localStorage.getItem(STORAGEID))).toEqual(state)
-  })
+describe("setGame", () => {
+  it("persists game state to localStorage", () => {
+    const state = { letters: [], grid: { height: 3, width: 3, rows: [] } };
+    setGame(state);
+    expect(JSON.parse(localStorage.getItem(STORAGEID))).toEqual(state);
+  });
 
-  it('returns the game object', () => {
-    const state = { letters: [], grid: defaultGame.grid }
-    expect(setGame(state)).toBe(state)
-  })
-})
+  it("returns the game object", () => {
+    const state = { letters: [], grid: defaultGame.grid };
+    expect(setGame(state)).toBe(state);
+  });
+});
 
-describe('setComplete', () => {
-  let $letters
+describe("setComplete", () => {
+  let $letters;
 
   beforeEach(() => {
-    $letters = document.getElementById('letters__list')
-    $letters.innerHTML = ''
-  })
+    $letters = document.getElementById("letters__list");
+    $letters.innerHTML = "";
+  });
 
-  it('adds complete class when all letter items are used', () => {
-    const li = document.createElement('li')
-    li.className = 'letters__item used'
-    $letters.appendChild(li)
-    setComplete($letters)
-    expect($letters.classList.contains('complete')).toBe(true)
-  })
+  it("adds complete class when all letter items are used", () => {
+    const li = document.createElement("li");
+    li.className = "letters__item used";
+    $letters.appendChild(li);
+    setComplete($letters);
+    expect($letters.classList.contains("complete")).toBe(true);
+  });
 
-  it('removes complete class when any letter item is unused', () => {
-    $letters.classList.add('complete')
-    const li = document.createElement('li')
-    li.className = 'letters__item'
-    $letters.appendChild(li)
-    setComplete($letters)
-    expect($letters.classList.contains('complete')).toBe(false)
-  })
+  it("removes complete class when any letter item is unused", () => {
+    $letters.classList.add("complete");
+    const li = document.createElement("li");
+    li.className = "letters__item";
+    $letters.appendChild(li);
+    setComplete($letters);
+    expect($letters.classList.contains("complete")).toBe(false);
+  });
 
-  it('returns true when complete', () => {
-    expect(setComplete($letters)).toBe(true)
-  })
+  it("returns true when complete", () => {
+    expect(setComplete($letters)).toBe(true);
+  });
 
-  it('returns false when not complete', () => {
-    const li = document.createElement('li')
-    li.className = 'letters__item'
-    $letters.appendChild(li)
-    expect(setComplete($letters)).toBe(false)
-  })
-})
+  it("returns false when not complete", () => {
+    const li = document.createElement("li");
+    li.className = "letters__item";
+    $letters.appendChild(li);
+    expect(setComplete($letters)).toBe(false);
+  });
+});

--- a/test/grid.test.js
+++ b/test/grid.test.js
@@ -1,4 +1,4 @@
-import { getGame, setGame } from '../src/scripts/game'
+import { getGame, setGame } from "../src/scripts/game";
 import {
   getHeight,
   getWidth,
@@ -11,129 +11,129 @@ import {
   addRowBottom,
   addColumnLeft,
   addColumnRight,
-} from '../src/scripts/grid'
+} from "../src/scripts/grid";
 
 const makeGame = (height = 3, width = 3) => ({
   letters: [],
   grid: {
     height,
     width,
-    rows: Array.from({ length: height }, () => Array(width).fill('')),
+    rows: Array.from({ length: height }, () => Array(width).fill("")),
   },
-})
+});
 
 beforeEach(() => {
-  localStorage.clear()
-  setGame(makeGame())
-  document.querySelector('#words__grid tbody').innerHTML = ''
-})
+  localStorage.clear();
+  setGame(makeGame());
+  document.querySelector("#words__grid tbody").innerHTML = "";
+});
 
-describe('getHeight / getWidth', () => {
-  it('reads height from game state', () => {
-    expect(getHeight()).toBe(3)
-  })
+describe("getHeight / getWidth", () => {
+  it("reads height from game state", () => {
+    expect(getHeight()).toBe(3);
+  });
 
-  it('reads width from game state', () => {
-    expect(getWidth()).toBe(3)
-  })
-})
+  it("reads width from game state", () => {
+    expect(getWidth()).toBe(3);
+  });
+});
 
-describe('setHeight / setWidth', () => {
-  it('persists height to game state', () => {
-    setHeight(7)
-    expect(getGame().grid.height).toBe(7)
-  })
+describe("setHeight / setWidth", () => {
+  it("persists height to game state", () => {
+    setHeight(7);
+    expect(getGame().grid.height).toBe(7);
+  });
 
-  it('persists width to game state', () => {
-    setWidth(5)
-    expect(getGame().grid.width).toBe(5)
-  })
-})
+  it("persists width to game state", () => {
+    setWidth(5);
+    expect(getGame().grid.width).toBe(5);
+  });
+});
 
-describe('updateGrid', () => {
-  it('saves a letter at the correct position', () => {
-    updateGrid('A', 1, 2)
-    expect(getGame().grid.rows[1][2]).toBe('A')
-  })
+describe("updateGrid", () => {
+  it("saves a letter at the correct position", () => {
+    updateGrid("A", 1, 2);
+    expect(getGame().grid.rows[1][2]).toBe("A");
+  });
 
-  it('does not affect other cells', () => {
-    updateGrid('Z', 0, 0)
-    expect(getGame().grid.rows[1][2]).toBe('')
-  })
-})
+  it("does not affect other cells", () => {
+    updateGrid("Z", 0, 0);
+    expect(getGame().grid.rows[1][2]).toBe("");
+  });
+});
 
-describe('createGridCell', () => {
-  it('creates a td with correct row and col attributes', () => {
-    const cell = createGridCell(1, 2, false)
-    expect(cell.tagName).toBe('TD')
-    expect(cell.dataset.row).toBe('1')
-    expect(cell.dataset.col).toBe('2')
-  })
+describe("createGridCell", () => {
+  it("creates a td with correct row and col attributes", () => {
+    const cell = createGridCell(1, 2, false);
+    expect(cell.tagName).toBe("TD");
+    expect(cell.dataset.row).toBe("1");
+    expect(cell.dataset.col).toBe("2");
+  });
 
-  it('populates cell value when stored letter exists', () => {
-    const game = makeGame()
-    game.grid.rows[0][0] = 'X'
-    setGame(game)
-    const cell = createGridCell(0, 0, true)
-    expect(cell.dataset.value).toBe('X')
-    expect(cell.classList.contains('used')).toBe(true)
-  })
+  it("populates cell value when stored letter exists", () => {
+    const game = makeGame();
+    game.grid.rows[0][0] = "X";
+    setGame(game);
+    const cell = createGridCell(0, 0, true);
+    expect(cell.dataset.value).toBe("X");
+    expect(cell.classList.contains("used")).toBe(true);
+  });
 
-  it('leaves cell empty when stored=false', () => {
-    const game = makeGame()
-    game.grid.rows[0][0] = 'X'
-    setGame(game)
-    const cell = createGridCell(0, 0, false)
-    expect(cell.dataset.value).toBeUndefined()
-    expect(cell.classList.contains('used')).toBe(false)
-  })
-})
+  it("leaves cell empty when stored=false", () => {
+    const game = makeGame();
+    game.grid.rows[0][0] = "X";
+    setGame(game);
+    const cell = createGridCell(0, 0, false);
+    expect(cell.dataset.value).toBeUndefined();
+    expect(cell.classList.contains("used")).toBe(false);
+  });
+});
 
-describe('createGridRow', () => {
-  it('creates a tr with the specified number of cells', () => {
-    const row = createGridRow(4, 0, false)
-    expect(row.tagName).toBe('TR')
-    expect(row.querySelectorAll('td')).toHaveLength(4)
-  })
-})
+describe("createGridRow", () => {
+  it("creates a tr with the specified number of cells", () => {
+    const row = createGridRow(4, 0, false);
+    expect(row.tagName).toBe("TR");
+    expect(row.querySelectorAll("td")).toHaveLength(4);
+  });
+});
 
-describe('addRowTop', () => {
-  it('increases grid height by 1', () => {
-    addRowTop()
-    expect(getGame().grid.height).toBe(4)
-  })
+describe("addRowTop", () => {
+  it("increases grid height by 1", () => {
+    addRowTop();
+    expect(getGame().grid.height).toBe(4);
+  });
 
-  it('adds a row to the top of the DOM', () => {
-    const tbody = document.querySelector('#words__grid tbody')
+  it("adds a row to the top of the DOM", () => {
+    const tbody = document.querySelector("#words__grid tbody");
     // seed a row so we can verify insertion position
-    tbody.appendChild(createGridRow(3, 0, false))
-    addRowTop()
-    expect(tbody.querySelectorAll('tr')).toHaveLength(2)
-    expect(tbody.firstChild.querySelectorAll('td')).toHaveLength(3)
-  })
-})
+    tbody.appendChild(createGridRow(3, 0, false));
+    addRowTop();
+    expect(tbody.querySelectorAll("tr")).toHaveLength(2);
+    expect(tbody.firstChild.querySelectorAll("td")).toHaveLength(3);
+  });
+});
 
-describe('addRowBottom', () => {
-  it('increases grid height by 1', () => {
-    addRowBottom()
-    expect(getGame().grid.height).toBe(4)
-  })
-})
+describe("addRowBottom", () => {
+  it("increases grid height by 1", () => {
+    addRowBottom();
+    expect(getGame().grid.height).toBe(4);
+  });
+});
 
-describe('addColumnLeft', () => {
-  it('increases grid width by 1', () => {
-    const tbody = document.querySelector('#words__grid tbody')
-    tbody.appendChild(createGridRow(3, 0, false))
-    addColumnLeft()
-    expect(getGame().grid.width).toBe(4)
-  })
-})
+describe("addColumnLeft", () => {
+  it("increases grid width by 1", () => {
+    const tbody = document.querySelector("#words__grid tbody");
+    tbody.appendChild(createGridRow(3, 0, false));
+    addColumnLeft();
+    expect(getGame().grid.width).toBe(4);
+  });
+});
 
-describe('addColumnRight', () => {
-  it('increases grid width by 1', () => {
-    const tbody = document.querySelector('#words__grid tbody')
-    tbody.appendChild(createGridRow(3, 0, false))
-    addColumnRight()
-    expect(getGame().grid.width).toBe(4)
-  })
-})
+describe("addColumnRight", () => {
+  it("increases grid width by 1", () => {
+    const tbody = document.querySelector("#words__grid tbody");
+    tbody.appendChild(createGridRow(3, 0, false));
+    addColumnRight();
+    expect(getGame().grid.width).toBe(4);
+  });
+});

--- a/test/keyboard.test.js
+++ b/test/keyboard.test.js
@@ -1,90 +1,90 @@
-import { handleKeyboard } from '../src/scripts/keyboard'
-import { vi } from 'vitest'
+import { handleKeyboard } from "../src/scripts/keyboard";
+import { vi } from "vitest";
 
 // Mock all modules that keyboard.js delegates to
-vi.mock('../src/scripts/game', () => ({
+vi.mock("../src/scripts/game", () => ({
   roll: vi.fn(),
-}))
-vi.mock('../src/scripts/grid', () => ({
+}));
+vi.mock("../src/scripts/grid", () => ({
   resetGrid: vi.fn(),
   addRowTop: vi.fn(),
   addRowBottom: vi.fn(),
   addColumnLeft: vi.fn(),
   addColumnRight: vi.fn(),
-}))
-vi.mock('../src/scripts/toggle', () => ({
+}));
+vi.mock("../src/scripts/toggle", () => ({
   toggleHeaderFooter: vi.fn(),
   toggleButtonText: vi.fn(),
-}))
+}));
 
-import { roll } from '../src/scripts/game'
+import { roll } from "../src/scripts/game";
 import {
   resetGrid,
   addRowTop,
   addRowBottom,
   addColumnLeft,
   addColumnRight,
-} from '../src/scripts/grid'
-import { toggleHeaderFooter, toggleButtonText } from '../src/scripts/toggle'
+} from "../src/scripts/grid";
+import { toggleHeaderFooter, toggleButtonText } from "../src/scripts/toggle";
 
 const ctrlKey = (keyCode) => {
-  const e = { ctrlKey: true, keyCode, preventDefault: vi.fn() }
-  handleKeyboard(e)
-  return e
-}
+  const e = { ctrlKey: true, keyCode, preventDefault: vi.fn() };
+  handleKeyboard(e);
+  return e;
+};
 
 beforeEach(() => {
-  vi.clearAllMocks()
-})
+  vi.clearAllMocks();
+});
 
-describe('handleKeyboard', () => {
-  it('does nothing without ctrlKey', () => {
-    handleKeyboard({ ctrlKey: false, keyCode: 13, preventDefault: vi.fn() })
-    expect(roll).not.toHaveBeenCalled()
-  })
+describe("handleKeyboard", () => {
+  it("does nothing without ctrlKey", () => {
+    handleKeyboard({ ctrlKey: false, keyCode: 13, preventDefault: vi.fn() });
+    expect(roll).not.toHaveBeenCalled();
+  });
 
-  it('Ctrl+Enter calls roll', () => {
-    ctrlKey(13)
-    expect(roll).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+Enter calls roll", () => {
+    ctrlKey(13);
+    expect(roll).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+Home calls resetGrid', () => {
-    ctrlKey(36)
-    expect(resetGrid).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+Home calls resetGrid", () => {
+    ctrlKey(36);
+    expect(resetGrid).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+ArrowLeft calls addColumnLeft', () => {
-    ctrlKey(37)
-    expect(addColumnLeft).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+ArrowLeft calls addColumnLeft", () => {
+    ctrlKey(37);
+    expect(addColumnLeft).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+ArrowUp calls addRowTop', () => {
-    ctrlKey(38)
-    expect(addRowTop).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+ArrowUp calls addRowTop", () => {
+    ctrlKey(38);
+    expect(addRowTop).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+ArrowRight calls addColumnRight', () => {
-    ctrlKey(39)
-    expect(addColumnRight).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+ArrowRight calls addColumnRight", () => {
+    ctrlKey(39);
+    expect(addColumnRight).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+ArrowDown calls addRowBottom', () => {
-    ctrlKey(40)
-    expect(addRowBottom).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+ArrowDown calls addRowBottom", () => {
+    ctrlKey(40);
+    expect(addRowBottom).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+Delete calls toggleHeaderFooter', () => {
-    ctrlKey(46)
-    expect(toggleHeaderFooter).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+Delete calls toggleHeaderFooter", () => {
+    ctrlKey(46);
+    expect(toggleHeaderFooter).toHaveBeenCalledTimes(1);
+  });
 
-  it('Ctrl+Space calls toggleButtonText', () => {
-    ctrlKey(32)
-    expect(toggleButtonText).toHaveBeenCalledTimes(1)
-  })
+  it("Ctrl+Space calls toggleButtonText", () => {
+    ctrlKey(32);
+    expect(toggleButtonText).toHaveBeenCalledTimes(1);
+  });
 
-  it('calls preventDefault for all Ctrl shortcuts', () => {
-    const e = ctrlKey(13)
-    expect(e.preventDefault).toHaveBeenCalled()
-  })
-})
+  it("calls preventDefault for all Ctrl shortcuts", () => {
+    const e = ctrlKey(13);
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,4 +8,4 @@ document.body.innerHTML = `
     <button id="toggleButtonText"><svg></svg><svg hidden="true"></svg></button>
     <span class="js-canHide"></span>
     <table id="words__grid"><tbody></tbody></table>
-`
+`;

--- a/test/toggle.test.js
+++ b/test/toggle.test.js
@@ -4,101 +4,101 @@ import {
   hideButtonText,
   toggleButtonText,
   swapIcons,
-} from '../src/scripts/toggle'
+} from "../src/scripts/toggle";
 
 beforeEach(() => {
-  localStorage.clear()
-  document.getElementById('header').className = ''
-  document.getElementById('footer').className = ''
-  document.querySelectorAll('span.js-canHide').forEach((el) => {
-    el.className = 'js-canHide'
-  })
-})
+  localStorage.clear();
+  document.getElementById("header").className = "";
+  document.getElementById("footer").className = "";
+  document.querySelectorAll("span.js-canHide").forEach((el) => {
+    el.className = "js-canHide";
+  });
+});
 
-describe('hideHeaderFooter', () => {
-  it('adds visually-hidden to header and footer', () => {
-    hideHeaderFooter()
+describe("hideHeaderFooter", () => {
+  it("adds visually-hidden to header and footer", () => {
+    hideHeaderFooter();
     expect(
-      document.getElementById('header').classList.contains('visually-hidden'),
-    ).toBe(true)
+      document.getElementById("header").classList.contains("visually-hidden"),
+    ).toBe(true);
     expect(
-      document.getElementById('footer').classList.contains('visually-hidden'),
-    ).toBe(true)
-  })
+      document.getElementById("footer").classList.contains("visually-hidden"),
+    ).toBe(true);
+  });
 
-  it('sets compress in localStorage', () => {
-    hideHeaderFooter()
-    expect(localStorage.getItem('compress')).toBe('true')
-  })
-})
+  it("sets compress in localStorage", () => {
+    hideHeaderFooter();
+    expect(localStorage.getItem("compress")).toBe("true");
+  });
+});
 
-describe('toggleHeaderFooter', () => {
-  it('hides header/footer when visible', () => {
-    toggleHeaderFooter()
+describe("toggleHeaderFooter", () => {
+  it("hides header/footer when visible", () => {
+    toggleHeaderFooter();
     expect(
-      document.getElementById('header').classList.contains('visually-hidden'),
-    ).toBe(true)
-  })
+      document.getElementById("header").classList.contains("visually-hidden"),
+    ).toBe(true);
+  });
 
-  it('shows header/footer when hidden', () => {
-    document.getElementById('header').classList.add('visually-hidden')
-    document.getElementById('footer').classList.add('visually-hidden')
-    toggleHeaderFooter()
+  it("shows header/footer when hidden", () => {
+    document.getElementById("header").classList.add("visually-hidden");
+    document.getElementById("footer").classList.add("visually-hidden");
+    toggleHeaderFooter();
     expect(
-      document.getElementById('header').classList.contains('visually-hidden'),
-    ).toBe(false)
-  })
+      document.getElementById("header").classList.contains("visually-hidden"),
+    ).toBe(false);
+  });
 
-  it('removes compress from localStorage when showing', () => {
-    localStorage.setItem('compress', 'true')
-    document.getElementById('header').classList.add('visually-hidden')
-    document.getElementById('footer').classList.add('visually-hidden')
-    toggleHeaderFooter()
-    expect(localStorage.getItem('compress')).toBeNull()
-  })
-})
+  it("removes compress from localStorage when showing", () => {
+    localStorage.setItem("compress", "true");
+    document.getElementById("header").classList.add("visually-hidden");
+    document.getElementById("footer").classList.add("visually-hidden");
+    toggleHeaderFooter();
+    expect(localStorage.getItem("compress")).toBeNull();
+  });
+});
 
-describe('hideButtonText', () => {
-  it('adds visually-hidden to button text spans', () => {
-    hideButtonText()
-    document.querySelectorAll('span.js-canHide').forEach((el) => {
-      expect(el.classList.contains('visually-hidden')).toBe(true)
-    })
-  })
+describe("hideButtonText", () => {
+  it("adds visually-hidden to button text spans", () => {
+    hideButtonText();
+    document.querySelectorAll("span.js-canHide").forEach((el) => {
+      expect(el.classList.contains("visually-hidden")).toBe(true);
+    });
+  });
 
-  it('sets iconsOnly in localStorage', () => {
-    hideButtonText()
-    expect(localStorage.getItem('iconsOnly')).toBe('true')
-  })
-})
+  it("sets iconsOnly in localStorage", () => {
+    hideButtonText();
+    expect(localStorage.getItem("iconsOnly")).toBe("true");
+  });
+});
 
-describe('toggleButtonText', () => {
-  it('hides button text when visible', () => {
-    toggleButtonText()
-    document.querySelectorAll('span.js-canHide').forEach((el) => {
-      expect(el.classList.contains('visually-hidden')).toBe(true)
-    })
-  })
+describe("toggleButtonText", () => {
+  it("hides button text when visible", () => {
+    toggleButtonText();
+    document.querySelectorAll("span.js-canHide").forEach((el) => {
+      expect(el.classList.contains("visually-hidden")).toBe(true);
+    });
+  });
 
-  it('shows button text when hidden', () => {
-    document.querySelectorAll('span.js-canHide').forEach((el) => {
-      el.classList.add('visually-hidden')
-    })
-    toggleButtonText()
-    document.querySelectorAll('span.js-canHide').forEach((el) => {
-      expect(el.classList.contains('visually-hidden')).toBe(false)
-    })
-  })
-})
+  it("shows button text when hidden", () => {
+    document.querySelectorAll("span.js-canHide").forEach((el) => {
+      el.classList.add("visually-hidden");
+    });
+    toggleButtonText();
+    document.querySelectorAll("span.js-canHide").forEach((el) => {
+      expect(el.classList.contains("visually-hidden")).toBe(false);
+    });
+  });
+});
 
-describe('swapIcons', () => {
-  it('toggles hidden attribute on SVG children', () => {
-    const btn = document.getElementById('toggleHeaderFooter')
-    const [first, second] = btn.querySelectorAll('svg')
-    const firstWasHidden = first.hasAttribute('hidden')
-    const secondWasHidden = second.hasAttribute('hidden')
-    swapIcons(btn)
-    expect(first.hasAttribute('hidden')).toBe(!firstWasHidden)
-    expect(second.hasAttribute('hidden')).toBe(!secondWasHidden)
-  })
-})
+describe("swapIcons", () => {
+  it("toggles hidden attribute on SVG children", () => {
+    const btn = document.getElementById("toggleHeaderFooter");
+    const [first, second] = btn.querySelectorAll("svg");
+    const firstWasHidden = first.hasAttribute("hidden");
+    const secondWasHidden = second.hasAttribute("hidden");
+    swapIcons(btn);
+    expect(first.hasAttribute("hidden")).toBe(!firstWasHidden);
+    expect(second.hasAttribute("hidden")).toBe(!secondWasHidden);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,52 +1,52 @@
-import { defineConfig } from 'vitest/config'
-import { readFileSync } from 'fs'
-import { fileURLToPath } from 'url'
-import { dirname, resolve } from 'path'
-import type { Plugin } from 'vite'
+import { defineConfig } from "vitest/config";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import type { Plugin } from "vite";
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function serviceWorkerPlugin() {
   return {
-    name: 'service-worker',
-    apply: 'build',
+    name: "service-worker",
+    apply: "build",
     generateBundle() {
-      const sw = readFileSync(resolve(__dirname, 'src/sw.js'), 'utf8').replace(
-        '{buildtime}',
+      const sw = readFileSync(resolve(__dirname, "src/sw.js"), "utf8").replace(
+        "{buildtime}",
         Date.now().toString(),
-      )
-      this.emitFile({ type: 'asset', fileName: 'sw.js', source: sw })
+      );
+      this.emitFile({ type: "asset", fileName: "sw.js", source: sw });
     },
-  }
+  };
 }
 
 export default defineConfig(({ mode }) => ({
-  root: 'src',
-  base: './',
+  root: "src",
+  base: "./",
   server: { port: 3080 },
   preview: { port: 3080 },
   build: {
-    outDir: mode === 'netlify' ? '../netlify' : '../dist',
+    outDir: mode === "netlify" ? "../netlify" : "../dist",
     emptyOutDir: true,
     rollupOptions: {
       output: {
-        entryFileNames: 'js/[name].js',
-        chunkFileNames: 'js/[name].js',
+        entryFileNames: "js/[name].js",
+        chunkFileNames: "js/[name].js",
         assetFileNames: (assetInfo) =>
-          /\.css$/i.test(assetInfo.name ?? '')
-            ? 'css/[name][extname]'
-            : 'assets/[name][extname]',
+          /\.css$/i.test(assetInfo.name ?? "")
+            ? "css/[name][extname]"
+            : "assets/[name][extname]",
       },
     },
   },
   plugins: [serviceWorkerPlugin()],
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: ['../test/setup.js'],
-    include: ['../test/**/*.test.js'],
+    setupFiles: ["../test/setup.js"],
+    include: ["../test/**/*.test.js"],
     coverage: {
-      provider: 'v8',
+      provider: "v8",
     },
   },
-}))
+}));


### PR DESCRIPTION
## Summary

- Reset `.prettierrc` from custom settings (`semi: false`, `singleQuote`, `tabWidth: 2`, `trailingComma`) to `{}` (all Prettier defaults)
- Ran a full format pass — purely cosmetic diff, no logic changes
- Updated CLAUDE.md code style note to reflect default settings

## Test plan

- [ ] Pre-commit hook passes (format:check + lint + tests)
- [ ] CI passes (format:check → lint → build → test)
- [ ] No functional changes — diff is whitespace/quote/semicolon only

🤖 Generated with [Claude Code](https://claude.com/claude-code)